### PR TITLE
Fix import for python build

### DIFF
--- a/wiringPi/piNes.c
+++ b/wiringPi/piNes.c
@@ -22,7 +22,7 @@
  ***********************************************************************
  */
 
-#include <wiringPi.h>
+#include ""wiringPi.h""
 
 #include "piNes.h"
 


### PR DESCRIPTION
Use other style import, for successful local build.

This resolves https://github.com/WiringPi/WiringPi-Python/issues/7
