### PR TITLE
Fix build error

### DIFF
--- a/wiringPi/piNes.c
+++ b/wiringPi/piNes.c
@@ -22,7 +22,7 @@
  ***********************************************************************
  */
 
-#include <wiringPi.h>
+#include "wiringPi.h"
 
 #include "piNes.h"
 


### PR DESCRIPTION
The last commit changes the include-syntax, so the build fails again.

Same problem as in issue #1