### PR TITLE
pass pin back to interrupt callback function

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -214,7 +214,7 @@ static int sysFds [64] ;
 
 // ISR Data
 
-static void (*isrFunctions [64])(void) ;
+static void (*isrFunctions [64])(int) ;
 
 
 // Doing it the Arduino way with lookup tables...
@@ -1064,7 +1064,7 @@ static void *interruptHandler (void *arg)
 
   for (;;)
     if (waitForInterruptSys (myPin, -1) > 0)
-      isrFunctions [myPin] () ;
+      isrFunctions [myPin] (myPin) ;
 
   return NULL ;
 }
@@ -1077,7 +1077,7 @@ static void *interruptHandler (void *arg)
  *********************************************************************************
  */
 
-int wiringPiISR (int pin, int mode, void (*function)(void))
+int wiringPiISR (int pin, int mode, void (*function)(int))
 {
   pthread_t threadId ;
   char fName   [64] ;

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -101,7 +101,7 @@ extern void (*pwmSetClock)       (int divisor) ;
 // Interrupts
 
 extern int  (*waitForInterrupt) (int pin, int mS) ;
-extern int  wiringPiISR         (int pin, int mode, void (*function)(void)) ;
+extern int  wiringPiISR         (int pin, int mode, void (*function)(int)) ;
 
 // Threads
 


### PR DESCRIPTION
I wanted to create one interrupt handler that handles all interrupt event. Passing the pin that the interrupt was detected on seemed like a logical thing to do here so I modified the code as such.