### PR TITLE
Keeping compatibility of hardware clock of Pi 4 with earlier versions.

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1218,6 +1218,11 @@ void pwmSetRange (unsigned int range)
 void pwmSetClock (int divisor)
 {
   uint32_t pwm_control ;
+
+  if (piGpioBase == GPIO_PERI_BASE_2711)
+  {
+    divisor = 540*divisor/192;
+  }
   divisor &= 4095 ;
 
   if ((wiringPiMode == WPI_MODE_PINS) || (wiringPiMode == WPI_MODE_PHYS) || (wiringPiMode == WPI_MODE_GPIO))


### PR DESCRIPTION
I added a code so that Pi 4 outputs hardware PWMs that have same frequencies as earlier versions.
This code does not affect the frequencies of software PWMs.

After this commit is merged, I will make a pull request to WiringPi-Python.