### PR TITLE
added length-specified (in addition to null-terminated) serial put

### DIFF
--- a/wiringPi/wiringSerial.c
+++ b/wiringPi/wiringSerial.c
@@ -171,6 +171,17 @@ void serialPuts (const int fd, const char *s)
 }
 
 /*
+ * serialPut:
+ *	Send an n character buffer to the serial port
+ *********************************************************************************
+ */
+
+void serialPut (const int fd, const char *s, const int n)
+{
+  write (fd, s, n) ;
+}
+
+/*
  * serialPrintf:
  *	Printf over Serial
  *********************************************************************************

--- a/wiringPi/wiringSerial.h
+++ b/wiringPi/wiringSerial.h
@@ -29,6 +29,7 @@ extern void  serialClose     (const int fd) ;
 extern void  serialFlush     (const int fd) ;
 extern void  serialPutchar   (const int fd, const unsigned char c) ;
 extern void  serialPuts      (const int fd, const char *s) ;
+extern void  serialPut       (const int fd, const char *s, const int n) ;
 extern void  serialPrintf    (const int fd, const char *message, ...) ;
 extern int   serialDataAvail (const int fd) ;
 extern int   serialGetchar   (const int fd) ;


### PR DESCRIPTION
I know wiringpi.com currently appears to be keeping its distance from github forks, but its git repository is also down and am not sure how else to contribute. I needed this function for a project of mine, and can't see any reason it isn't already included (except that "wiringSerial" is likely a little-used module which doesn't get a lot of attention). Let me know if there are better means of contributing to this project in a more permanent way, and also please let me know if there are disagreements about the function name/signature/etc...