### PR TITLE
Update gpio.c to fix wiringPiSetup error in node-red-node-piface 0.0.8

### DIFF
--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -1436,6 +1436,7 @@ int main (int argc, char *argv [])
 
   else if (strcasecmp (argv [1], "-p") == 0)
   {
+    wiringPiSetupSys () ;
     piFaceSetup (200) ;
 
     for (i = 2 ; i < argc ; ++i)


### PR DESCRIPTION
Fix You have not called one of the wiringPiSetup when using gpio -p option (in node-red-node-piface 0.0.8)