### PR TITLE
Update mcp3002.c

### DIFF
--- a/wiringPi/mcp3002.c
+++ b/wiringPi/mcp3002.c
@@ -49,7 +49,7 @@ static int myAnalogRead (struct wiringPiNodeStruct *node, int pin)
 
   wiringPiSPIDataRW (node->fd, spiData, 2) ;
 
-  return ((spiData [0] << 8) | (spiData [1] >> 1)) & 0x3FF ;
+  return ((spiData [0] << 7) | (spiData [1] >> 1)) & 0x3FF ;
 }
 
 


### PR DESCRIPTION
fixed: wrong value for bitwise left shift
tested using a MCP3002-I/SN with raspberry pi 3 b+ running Raspbian  GNU/Linux 9.11
measured devices: 5k slide potentiometer & dwyer 628