### PR TITLE
Update README.md to clarify project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
-Unofficial WiringPi Mirror
-==========================
+WiringPi (Unofficial Mirror/Fork)
+=================================
 
-This is an unofficial mirror of WiringPi to support ports (Python/Ruby/etc).  With the
+This is an unofficial mirror/fork of wiringPi to support ports (Python/Ruby/etc).  With the
 [end of official development](http://wiringpi.com/wiringpi-deprecated/), this repository
-has become a mirror of the last "official" source release as well as a source for small
-updates to support newer hardware (primarily for use by the ports).
+has become a mirror of the last "official" source release, plus a fork to facilitate updates
+to support newer hardware (primarily for use by the ports) and fix bugs.
+
+  * The final "official" source release can be found at the
+    [`final_source_2.50`](https://github.com/WiringPi/WiringPi/tree/final_official_2.50) tag.
+  * The default `master` branch contains code that has been written since that final source
+    release to provide support for newer hardware.
+
+Ports
+-----
+
+wiringPi has been wrapped for multiple languages:
+
+* Node - https://github.com/WiringPi/WiringPi-Node
+* Perl - https://github.com/WiringPi/WiringPi-Perl
+* PHP - https://github.com/WiringPi/WiringPi-PHP
+* Python - https://github.com/WiringPi/WiringPi-Python
+* Ruby - https://github.com/WiringPi/WiringPi-Ruby
+
+Support
+-------
+
+Please do not email Gordon if you have issues, he will not be able to help.
+
+Pull-requests may be accepted to add or fix support for newer hardware, but new features or
+other changes will not be accepted.
+
+For support, comments, questions, etc please join the WiringPi Discord channel: https://discord.gg/SM4WUVG
 
   * The final "official" source release can be found at the
     [`final_source_2.50`](https://github.com/WiringPi/WiringPi/tree/final_official_2.50) tag.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WiringPi (Unofficial Mirror/Fork)
 
 This is an unofficial mirror/fork of wiringPi to support ports (Python/Ruby/etc).  With the
 [end of official development](http://wiringpi.com/wiringpi-deprecated/), this repository
-has become a mirror of the last "official" source release, plus a fork to facilitate updates
+has become a mirror of the last "official" source release, plus a fork facilitating updates
 to support newer hardware (primarily for use by the ports) and fix bugs.
 
   * The final "official" source release can be found at the
@@ -28,18 +28,6 @@ Support
 Please do not email Gordon if you have issues, he will not be able to help.
 
 Pull-requests may be accepted to add or fix support for newer hardware, but new features or
-other changes will not be accepted.
-
-For support, comments, questions, etc please join the WiringPi Discord channel: https://discord.gg/SM4WUVG
-
-  * The final "official" source release can be found at the
-    [`final_source_2.50`](https://github.com/WiringPi/WiringPi/tree/final_official_2.50) tag.
-  * The default `master` branch contains code that has been written since that final source
-    release to provide support for newer hardware.
-
-Please do not email Gordon if you have issues, he will not be able to help.
-
-Pull-requests may be accepted to add or fix support for newer hardware, but new features or
-other changes will not be accepted.
+other changes may not be accepted.
 
 For support, comments, questions, etc please join the WiringPi Discord channel: https://discord.gg/SM4WUVG


### PR DESCRIPTION
This change updates the README.md to clarify the status of this wiringPi fork, draw attention to ports and redirect support questions to the wiringPi discord.