### PR TITLE
Add support for Pi 400 and CM4

### DIFF
--- a/gpio/readall.c
+++ b/gpio/readall.c
@@ -311,6 +311,8 @@ static void plus2header (int model)
     printf (" +-----+-----+---------+------+---+---Pi 3A+-+---+------+---------+-----+-----+\n") ;
   else if (model == PI_MODEL_4B)
     printf (" +-----+-----+---------+------+---+---Pi 4B--+---+------+---------+-----+-----+\n") ;
+  else if (model == PI_MODEL_400)
+    printf (" +-----+-----+---------+------+---+---Pi 400-+---+------+---------+-----+-----+\n") ;
   else
     printf (" +-----+-----+---------+------+---+---Pi ?---+---+------+---------+-----+-----+\n") ;
 }
@@ -358,10 +360,10 @@ void doReadall (void)
 	(model == PI_MODEL_2)    ||
 	(model == PI_MODEL_3AP)  ||
 	(model == PI_MODEL_3B)   || (model == PI_MODEL_3BP) ||
-	(model == PI_MODEL_4B)   ||
+	(model == PI_MODEL_4B)   || (model == PI_MODEL_400) ||
 	(model == PI_MODEL_ZERO) || (model == PI_MODEL_ZERO_W))
     piPlusReadall (model) ;
-  else if ((model == PI_MODEL_CM) || (model == PI_MODEL_CM3) || ((model == PI_MODEL_CM3P)))
+  else if ((model == PI_MODEL_CM) || (model == PI_MODEL_CM3) || (model == PI_MODEL_CM3P) || (model == PI_MODEL_CM4))
     allReadall () ;
   else
     printf ("Oops - unable to determine board type... model: %d\n", model) ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -219,7 +219,7 @@ volatile unsigned int *_wiringPiTimerIrqRaw ;
 
 static volatile unsigned int piGpioBase = 0 ;
 
-const char *piModelNames [20] =
+const char *piModelNames [21] =
 {
   "Model A",	//  0
   "Model B",	//  1
@@ -240,7 +240,8 @@ const char *piModelNames [20] =
   "CM3+",	// 16
   "Pi 4B",	// 17
   "Unknown18",	// 18
-  "Unknown19",	// 19
+  "Pi 400",	// 19
+  "CM4",	// 20
 } ;
 
 const char *piRevisionNames [16] =
@@ -2312,6 +2313,8 @@ int wiringPiSetup (void)
       break ;
 
     case PI_MODEL_4B:
+    case PI_MODEL_400:
+    case PI_MODEL_CM4:
       piGpioBase = GPIO_PERI_BASE_2711 ;
       piGpioPupOffset = GPPUPPDN0 ;
       break ;

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -103,6 +103,8 @@
 #define	PI_MODEL_3AP 		14
 #define	PI_MODEL_CM3P 		16
 #define	PI_MODEL_4B 		17
+#define	PI_MODEL_400		19
+#define	PI_MODEL_CM4		20
 
 #define	PI_VERSION_1		0
 #define	PI_VERSION_1_1		1
@@ -114,7 +116,7 @@
 #define	PI_MAKER_EMBEST		2
 #define	PI_MAKER_UNKNOWN	3
 
-extern const char *piModelNames    [20] ;
+extern const char *piModelNames    [21] ;
 extern const char *piRevisionNames [16] ;
 extern const char *piMakerNames    [16] ;
 extern const int   piMemorySize    [ 8] ;


### PR DESCRIPTION
- just use same GPIO_PERI_BASE_2711 as Pi4
- add to readall - 400 as 4B, CM4 as previous CM

Seems to work for me with Pi400, don't have CM4 to test.

resolves #88 