### PR TITLE
Remove projects@drogon.net contact from build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,7 +23,11 @@ To un-install wiringPi:
 
   ./build uninstall
 
-Gordon Henderson
+For help and support see:
 
-projects@drogon.net
+* https://github.com/WiringPi/WiringPi/issues
+* https://discord.gg/SM4WUVG
+
+
+wiringPi originally created by Gordon Henderson
 https://projects.drogon.net/

--- a/build
+++ b/build
@@ -36,8 +36,8 @@ check_make_ok() {
     echo ""
     echo "Make Failed..."
     echo "Please check the messages and fix any problems. If you're still stuck,"
-    echo "then please email all the output and as many details as you can to"
-    echo "  projects@drogon.net"
+    echo "then raise a GitHub issue with the output and as many details as you can"
+    echo "  https://github.com/WiringPi/WiringPi/issues"
     echo ""
     exit 1
   fi

--- a/gpio/gpio.1
+++ b/gpio/gpio.1
@@ -337,7 +337,7 @@ Gordon Henderson
 
 .SH "REPORTING BUGS"
 
-Please report bugs to <projects@drogon.net>
+Please report bugs to https://github.com/WiringPi/WiringPi/issues
 
 .SH COPYRIGHT
 


### PR DESCRIPTION
In an effort to avoid any unecessary contact with Gordon, I've updated the build output error instructions to direct users to raise an issue.