### PR TITLE
set pin numbering scheme for CM4 same as older CMs

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2284,7 +2284,8 @@ int wiringPiSetup (void)
 
   if ((model == PI_MODEL_CM) ||
       (model == PI_MODEL_CM3) ||
-      (model == PI_MODEL_CM3P))
+      (model == PI_MODEL_CM3P) ||
+      (model == PI_MODEL_CM4))
     wiringPiMode = WPI_MODE_GPIO ;
   else
     wiringPiMode = WPI_MODE_PINS ;


### PR DESCRIPTION
set WPI_MODE_GPIO as a default pin numbering mode also for CM4

Forgot  this bit in Pi400+CM4 support.

There are two basic pin numbering schemes - broadcom and custom wiringpi as per http://wiringpi.com/reference/setup/ and for compute modules the default wiringpi mode makes less sense as it is based on 40pin connector which is not used with CM.

For CM4 there is IO board with 40pin connector so there it makes some sense. However to keep it aligned with previous CMs I guess having broadcom mode based on real GPIO numbers by default  still makes better sense. 