### PR TITLE
fixes WiringPi/WiringPi#100

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2049,7 +2049,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
 	return wiringPiFailure (WPI_FATAL, "wiringPiISR: Can't find gpio program\n") ;
     }
     else		// Parent, wait
-      wait (NULL) ;
+      waitpid (pid, NULL, 0) ;
   }
 
 // Now pre-open the /sys/class node - but it may already be open if


### PR DESCRIPTION
The change now waits on the specific forked process, avoiding other child processes being picked up.

This behavior for linux >= 2.4 where it can wait on child processes created by other threads is described [here](https://www.man7.org/linux/man-pages/man2/waitpid.2.html):

>     In the Linux kernel, a kernel-scheduled thread is not a distinct
       construct from a process.  Instead, a thread is simply a process
       that is created using the Linux-unique clone(2) system call;
       other routines such as the portable pthread_create(3) call are
       implemented using clone(2).  Before Linux 2.4, a thread was just
       a special case of a process, and as a consequence one thread
       could not wait on the children of another thread, even when the
       latter belongs to the same thread group.  However, POSIX
       prescribes such functionality, and since Linux 2.4 a thread can,
       and by default will, wait on children of other threads in the
       same thread group.

See #100 for more context.