### PR TITLE
waitForInterrupt is now essentially wiringPiISR but blocking

### DIFF
--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -242,7 +242,7 @@ extern          void digitalWriteByte2   (int value) ;
 // Interrupts
 //	(Also Pi hardware specific)
 
-extern int  waitForInterrupt    (int pin, int mS) ;
+extern int  waitForInterrupt    (int pin, int mS, int mode) ;
 extern int  wiringPiISR         (int pin, int mode, void (*function)(void)) ;
 
 // Threads


### PR DESCRIPTION
waitForInterrupt wasn't working anymore. Documentation says it's been deprecated since 2013 but was still being used by the `interruptHandler` employed by `wiringPiISR`.
https://github.com/WiringPi/WiringPi/blob/22fac72e1a45261c0089904718bd89a72cba3b68/wiringPi/wiringPi.c#L1978
It was still working via `wiringPiISR`, and not directly, because ISR handles the setup. This has now been changed, however, it might break some implementations so suggestions on how to do this in a better manner would be greatly appreciated!