### PR TITLE
feat(serial): add timeout option when opening port

### DIFF
--- a/wiringPi/wiringSerial.h
+++ b/wiringPi/wiringSerial.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+extern int   serialOpenWithTimeout (const char *device, const int baud, int timeout) ;
 extern int   serialOpen      (const char *device, const int baud) ;
 extern void  serialClose     (const int fd) ;
 extern void  serialFlush     (const int fd) ;


### PR DESCRIPTION
when opening a serial with `serialOpen(const char *device, const int baud)`, is set a default timeout of 10 seconds.

this PR creates a separate function `serialOpenWithTimeout(const char *device, const int baud, int timeout)` to allow the user to define a different timeout:
- `timeout` is expressed in tenth of seconds, as that is the minimum resolution achievable
- if `timeout=0`, will be a non-blocking polling (option `MIN == 0, TIME == 0` on [termios(3)](https://man7.org/linux/man-pages/man3/termios.3.html))
- a check is made to ensure `timeout` is positive and at most 255 (25.5 seconds)

the original `serialOpen()` still works as intended and calls `serialOpenWithTimeout()` with a timeout of 100 (10 seconds default), making this feature back-compatible