### PR TITLE
LIBS have to come after OBJ files for recent GCC

### DIFF
--- a/wiringPi/Makefile
+++ b/wiringPi/Makefile
@@ -75,7 +75,7 @@ static:
 
 $(DYNAMIC):	$(OBJ)
 	$Q echo "[Link (Dynamic)]"
-	$Q $(CC) -shared -Wl,-soname,libwiringPi.so$(WIRINGPI_SONAME_SUFFIX) -o libwiringPi.so.$(VERSION) $(LIBS) $(OBJ)
+	$Q $(CC) -shared -Wl,-soname,libwiringPi.so$(WIRINGPI_SONAME_SUFFIX) -o libwiringPi.so.$(VERSION) $(OBJ) $(LIBS)
 
 .c.o:
 	$Q echo [Compile] $<


### PR DESCRIPTION
With recent GCC versions, the ordering matters. For proper dynamic linking, the LIBS have to come after the OBJ files.

https://stackoverflow.com/questions/35897290/what-is-the-right-order-of-linker-flags-in-gcc