### PR TITLE
Return error from `softPwmCreate` if `pthread_create` fails

### DIFF
--- a/wiringPi/softPwm.c
+++ b/wiringPi/softPwm.c
@@ -153,6 +153,9 @@ int softPwmCreate (int pin, int initialValue, int pwmRange)
   newPin   = pin ;
   res      = pthread_create (&myThread, NULL, softPwmThread, (void *)passPin) ;
 
+  if (res != 0)
+    return res ;
+  
   while (newPin != -1)
     delay (1) ;
 


### PR DESCRIPTION
If `pthread_create` fails, `newPin` will never get reset to -1 and process would hang. This change will return from `softPwmCreate` immediately if  `pthread_create` returns a non-zero value and avoid hanging forever.