### PR TITLE
Fixed the Compute Module 4 pin mode setting.

### DIFF
--- a/gpio/readall.c
+++ b/gpio/readall.c
@@ -361,9 +361,9 @@ void doReadall (void)
 	(model == PI_MODEL_3AP)  ||
 	(model == PI_MODEL_3B)   || (model == PI_MODEL_3BP) ||
 	(model == PI_MODEL_4B)   || (model == PI_MODEL_400) ||
-	(model == PI_MODEL_ZERO) || (model == PI_MODEL_ZERO_W))
+	(model == PI_MODEL_ZERO) || (model == PI_MODEL_ZERO_W) || (model == PI_MODEL_CM4))
     piPlusReadall (model) ;
-  else if ((model == PI_MODEL_CM) || (model == PI_MODEL_CM3) || (model == PI_MODEL_CM3P) || (model == PI_MODEL_CM4))
+  else if ((model == PI_MODEL_CM) || (model == PI_MODEL_CM3) || (model == PI_MODEL_CM3P) )
     allReadall () ;
   else
     printf ("Oops - unable to determine board type... model: %d\n", model) ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2284,8 +2284,7 @@ int wiringPiSetup (void)
 
   if ((model == PI_MODEL_CM) ||
       (model == PI_MODEL_CM3) ||
-      (model == PI_MODEL_CM3P) ||
-      (model == PI_MODEL_CM4))
+      (model == PI_MODEL_CM3P))
     wiringPiMode = WPI_MODE_GPIO ;
   else
     wiringPiMode = WPI_MODE_PINS ;


### PR DESCRIPTION
Compute Module 4 is equal to std platform Rasberry 3, 4 etc, not CM3 family as one might think.
This is a small fix and I have an application that uses at GPIO, Serial and i2c which I have verified.