### PR TITLE
Pre-create binary directory before copying binary

### DIFF
--- a/gpio/Makefile
+++ b/gpio/Makefile
@@ -72,6 +72,7 @@ tags:	$(SRC)
 .PHONY:	install
 install: gpio
 	$Q echo "[Install]"
+	$Q mkdir -p		$(DESTDIR)$(PREFIX)/bin
 	$Q cp gpio		$(DESTDIR)$(PREFIX)/bin
 ifneq ($(WIRINGPI_SUID),0)
 	$Q chown root.root	$(DESTDIR)$(PREFIX)/bin/gpio


### PR DESCRIPTION
This may exist in most cases, but occasionally it does not and it aligns with the way the man page directory is pre-created as well.