### PR TITLE
Reduce size of a buffer to quiet a spurious warning.  Fixes #133.

### DIFF
--- a/wiringPi/drcNet.c
+++ b/wiringPi/drcNet.c
@@ -76,12 +76,12 @@ static int remoteReadline (int fd, char *buf, int max)
 
 static char *getChallenge (int fd)
 {
-  static char buf [1024] ;
+  static char buf [512] ;
   int num ;
 
   for (;;)
   {
-    if ((num = remoteReadline (fd, buf, 1023)) < 0)
+    if ((num = remoteReadline (fd, buf, 511)) < 0)
       return NULL ;
     buf [num] = 0 ;
 


### PR DESCRIPTION
A recent compiler complains about the sprintf() in authenticate() being able to
write up to 1023 bytes into challenge, which is not possible given that getChallenge()
returns a string 10 bytes smaller than whatever string is in its 1024 byte buffer.
Reducing the size of the buffer in getChallenge() quiets the warning.  It should not
affect anything else, as the challenge string is used as a salt that must be <= 96 bits.