### PR TITLE
Adds ability to remove a node from the device tree

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1369,6 +1369,53 @@ struct wiringPiNodeStruct *wiringPiNewNode (int pinBase, int numPins)
   return node ;
 }
 
+/*
+ * wiringPiRemoveNode:
+ *	Remove an existing GPIO node from the wiringPi handling system
+ *********************************************************************************
+ */
+
+int wiringPiRemoveNode (int pinBase)
+{
+  struct wiringPiNodeStruct *node ;
+  struct wiringPiNodeStruct *nodePrevious ;
+
+// Don't try if there are no nodes in the tree or pinBase in naitive GPI range
+  if (wiringPiNodes == NULL || pinBase < 64)
+    return FALSE;
+
+// Find node
+  node = wiringPiFindNode (pinBase) ;
+  if (node == NULL)
+    return FALSE;
+
+// Remove node pointer from tree
+  if (node == wiringPiNodes)
+  {
+    wiringPiNodes = node->next;
+  }
+  else
+  {
+
+    nodePrevious = wiringPiNodes;
+
+    while (nodePrevious != NULL) {
+      if (nodePrevious->next == node) {
+        nodePrevious->next = node->next;
+        break;
+      }
+      nodePrevious = nodePrevious->next;
+    }
+  }
+
+  //!@todo Run device specific code
+
+  // Recover memory allocated to node
+  free(node);
+
+  return TRUE ;
+}
+
 
 #ifdef notYetReady
 /*

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -198,6 +198,7 @@ extern int wiringPiFailure (int fatal, const char *message, ...) ;
 
 extern struct wiringPiNodeStruct *wiringPiFindNode (int pin) ;
 extern struct wiringPiNodeStruct *wiringPiNewNode  (int pinBase, int numPins) ;
+extern int wiringPiRemoveNode  (int pinBase) ;
 
 extern void wiringPiVersion	(int *major, int *minor) ;
 extern int  wiringPiSetup       (void) ;


### PR DESCRIPTION
This pull request implements feature request #147. A new function `int wiringPiRemoveNode(int basePin)` will check if there is a node with the requested base pin, remove it from the linked list of nodes and free the space it uses. The function returns TRUE on success of FALSE if removal cannot be performed, e.g. node does not exist.