### PR TITLE
Feature/#146 add node fail gracefully

### DIFF
--- a/devLib/gertboard.c
+++ b/devLib/gertboard.c
@@ -153,10 +153,15 @@ int gertboardAnalogSetup (const int pinBase)
   struct wiringPiNodeStruct *node ;
   int    x ;
 
-  if (( x = gertboardSPISetup ()) != 0)
-    return  x;
+  if ((node = wiringPiNewNode (pinBase, 2)) == NULL)
+    return -1 ;
 
-  node = wiringPiNewNode (pinBase, 2) ;
+  if (( x = gertboardSPISetup ()) != 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return  x ;
+  }
+
   node->analogRead  = myAnalogRead ;
   node->analogWrite = myAnalogWrite ;
 

--- a/devLib/piFace.c
+++ b/devLib/piFace.c
@@ -93,7 +93,8 @@ int piFaceSetup (const int pinBase)
 
 // Create an mcp23s17 instance:
 
-   mcp23s17Setup (pinBase + 16, 0, 0) ;
+   if (mcp23s17Setup (pinBase + 16, 0, 0) == FALSE)
+    return -1;
 
 // Set the direction bits
 

--- a/wiringPi/ads1115.c
+++ b/wiringPi/ads1115.c
@@ -196,7 +196,7 @@ static int myAnalogRead (struct wiringPiNodeStruct *node, int pin)
 // Sometimes with a 0v input on a single-ended channel the internal 0v reference
 //	can be higher than the input, so you get a negative result...
 
-  if ( (chan < 4) && (result < 0) ) 
+  if ( (chan < 4) && (result < 0) )
     return 0 ;
   else
     return (int)result ;
@@ -230,7 +230,7 @@ static void myDigitalWrite (struct wiringPiNodeStruct *node, int pin, int data)
       data = 4 ;
     node->data1 = dataRates [data] ;	// Bugfix 0-1 by "Eric de jong (gm)" <ericdejong@gmx.net> - Thanks.
   }
-  
+
 }
 
 
@@ -277,10 +277,15 @@ int ads1115Setup (const int pinBase, int i2cAddr)
   struct wiringPiNodeStruct *node ;
   int fd ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddr)) < 0)
+  node = wiringPiNewNode (pinBase, 8) ;
+  if(node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 8) ;
+  if ((fd = wiringPiI2CSetup (i2cAddr)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd           = fd ;
   node->data0        = CONFIG_PGA_4_096V ;	// Gain in data0

--- a/wiringPi/bmp180.c
+++ b/wiringPi/bmp180.c
@@ -191,10 +191,15 @@ int bmp180Setup (const int pinBase)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
+  node = wiringPiNewNode (pinBase, 4) ;
+  if(node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 4) ;
+  if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd          = fd ;
   node->analogRead  = myAnalogRead ;

--- a/wiringPi/drcNet.c
+++ b/wiringPi/drcNet.c
@@ -111,7 +111,7 @@ static int authenticate (int fd, const char *pass)
 
   sprintf (salted, "$6$%s$", challenge) ;
   encrypted = crypt (pass, salted) ;
-  
+
 // This is an assertion, or sanity check on my part...
 //	The '20' comes from the $6$ then the 16 characters of the salt,
 //	then the terminating $.
@@ -379,15 +379,23 @@ int drcSetupNet (const int pinBase, const int numPins, const char *ipAddress, co
   int fd, len ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = _drcSetupNet (ipAddress, port, password)) < 0)
+  node = wiringPiNewNode (pinBase, numPins) ;
+  if(node == NULL)
     return FALSE ;
+
+  if ((fd = _drcSetupNet (ipAddress, port, password)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   len = sizeof (struct drcNetComStruct) ;
 
   if (setsockopt (fd, SOL_SOCKET, SO_RCVLOWAT, (void *)&len, sizeof (len)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
     return FALSE ;
-
-  node = wiringPiNewNode (pinBase, numPins) ;
+  }
 
   node->fd               = fd ;
   node->pinMode          = myPinMode ;

--- a/wiringPi/drcSerial.c
+++ b/wiringPi/drcSerial.c
@@ -178,11 +178,14 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
 
   if (!ok)
   {
-    serialClose (fd) ;
     return FALSE ;
   }
 
   node = wiringPiNewNode (pinBase, numPins) ;
+  if(node == NULL) {
+    serialClose (fd) ;
+    return FALSE ;
+  }
 
   node->fd              = fd ;
   node->pinMode         = myPinMode ;

--- a/wiringPi/ds18b20.c
+++ b/wiringPi/ds18b20.c
@@ -138,6 +138,11 @@ int ds18b20Setup (const int pinBase, const char *deviceId)
 //	although it's very slow reading these things anyway )-:
 
   node = wiringPiNewNode (pinBase, 1) ;
+  if(node == NULL)
+  {
+    close(fd) ;
+    return FALSE ;
+  }
 
   node->fd         = fd ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/htu21d.c
+++ b/wiringPi/htu21d.c
@@ -126,10 +126,16 @@ int htu21dSetup (const int pinBase)
   uint8_t data ;
   int status ;
 
-  if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
+  node = wiringPiNewNode (pinBase, 2) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 2) ;
+  if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
+
 
   node->fd         = fd ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/max31855.c
+++ b/wiringPi/max31855.c
@@ -24,6 +24,7 @@
 
 #include <byteswap.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
@@ -87,10 +88,16 @@ int max31855Setup (const int pinBase, int spiChannel)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiChannel, 5000000) < 0)	// 5MHz - prob 4 on the Pi
+  node = wiringPiNewNode (pinBase, 4) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 4) ;
+  if (wiringPiSPISetup (spiChannel, 5000000) < 0)	// 5MHz - prob 4 on the Pi
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
+
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/max5322.c
+++ b/wiringPi/max5322.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stddef.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -65,10 +67,15 @@ int max5322Setup (const int pinBase, int spiChannel)
   struct wiringPiNodeStruct *node ;
   unsigned char spiData [2] ;
 
-  if (wiringPiSPISetup (spiChannel, 8000000) < 0)	// 10MHz Max
+  node = wiringPiNewNode (pinBase, 2) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 2) ;
+  if (wiringPiSPISetup (spiChannel, 8000000) < 0)	// 10MHz Max
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd          = spiChannel ;
   node->analogWrite = myAnalogWrite ;
@@ -77,7 +84,7 @@ int max5322Setup (const int pinBase, int spiChannel)
 
   spiData [0] = 0b11100000 ;
   spiData [1] = 0 ;
-  
+
   wiringPiSPIDataRW (node->fd, spiData, 2) ;
 
   return TRUE ;

--- a/wiringPi/mcp23008.c
+++ b/wiringPi/mcp23008.c
@@ -113,7 +113,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -131,12 +131,18 @@ int mcp23008Setup (const int pinBase, const int i2cAddress)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 8) ;
+  if (node == NULL)
     return FALSE ;
+
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   wiringPiI2CWriteReg8 (fd, MCP23x08_IOCON, IOCON_INIT) ;
 
-  node = wiringPiNewNode (pinBase, 8) ;
 
   node->fd              = fd ;
   node->pinMode         = myPinMode ;

--- a/wiringPi/mcp23016.c
+++ b/wiringPi/mcp23016.c
@@ -127,7 +127,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -145,13 +145,19 @@ int mcp23016Setup (const int pinBase, const int i2cAddress)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 16) ;
+  if (node == NULL)
     return FALSE ;
+
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   wiringPiI2CWriteReg8 (fd, MCP23016_IOCON0, IOCON_INIT) ;
   wiringPiI2CWriteReg8 (fd, MCP23016_IOCON1, IOCON_INIT) ;
 
-  node = wiringPiNewNode (pinBase, 16) ;
 
   node->fd              = fd ;
   node->pinMode         = myPinMode ;

--- a/wiringPi/mcp23017.c
+++ b/wiringPi/mcp23017.c
@@ -22,8 +22,7 @@
  ***********************************************************************
  */
 
-#include <stdio.h>
-#include <pthread.h>
+#include <stddef.h>
 
 #include "wiringPi.h"
 #include "wiringPiI2C.h"
@@ -158,7 +157,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -176,12 +175,18 @@ int mcp23017Setup (const int pinBase, const int i2cAddress)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 16) ;
+  if(node == NULL)
     return FALSE ;
+
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   wiringPiI2CWriteReg8 (fd, MCP23x17_IOCON, IOCON_INIT) ;
 
-  node = wiringPiNewNode (pinBase, 16) ;
 
   node->fd              = fd ;
   node->pinMode         = myPinMode ;

--- a/wiringPi/mcp23s08.c
+++ b/wiringPi/mcp23s08.c
@@ -152,7 +152,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -169,12 +169,18 @@ int mcp23s08Setup (const int pinBase, const int spiPort, const int devId)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
+  node = wiringPiNewNode (pinBase, 8) ;
+  if (node == NULL)
     return FALSE ;
+
+  if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   writeByte (spiPort, devId, MCP23x08_IOCON, IOCON_INIT) ;
 
-  node = wiringPiNewNode (pinBase, 8) ;
 
   node->data0           = spiPort ;
   node->data1           = devId ;

--- a/wiringPi/mcp23s17.c
+++ b/wiringPi/mcp23s17.c
@@ -197,7 +197,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -214,13 +214,19 @@ int mcp23s17Setup (const int pinBase, const int spiPort, const int devId)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
+  node = wiringPiNewNode (pinBase, 16) ;
+  if (node == NULL)
     return FALSE ;
+
+  if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   writeByte (spiPort, devId, MCP23x17_IOCON,  IOCON_INIT | IOCON_HAEN) ;
   writeByte (spiPort, devId, MCP23x17_IOCONB, IOCON_INIT | IOCON_HAEN) ;
 
-  node = wiringPiNewNode (pinBase, 16) ;
 
   node->data0           = spiPort ;
   node->data1           = devId ;

--- a/wiringPi/mcp3002.c
+++ b/wiringPi/mcp3002.c
@@ -22,10 +22,13 @@
  ***********************************************************************
  */
 
+#include <stddef.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
 #include "mcp3002.h"
+
 
 /*
  * myAnalogRead:
@@ -64,10 +67,15 @@ int mcp3002Setup (const int pinBase, int spiChannel)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  node = wiringPiNewNode (pinBase, 2) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 2) ;
+  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/mcp3004.c
+++ b/wiringPi/mcp3004.c
@@ -24,6 +24,8 @@
  ***********************************************************************
  */
 
+#include <stddef.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -64,10 +66,15 @@ int mcp3004Setup (const int pinBase, int spiChannel)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  node = wiringPiNewNode (pinBase, 8) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 8) ;
+  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/mcp3422.c
+++ b/wiringPi/mcp3422.c
@@ -70,7 +70,7 @@ int myAnalogRead (struct wiringPiNodeStruct *node, int chan)
 // One-shot mode, trigger plus the other configs.
 
   config = 0x80 | (realChan << 5) | (node->data0 << 2) | (node->data1) ;
-  
+
   wiringPiI2CWrite (node->fd, config) ;
 
   switch (node->data0)	// Sample rate
@@ -111,10 +111,15 @@ int mcp3422Setup (int pinBase, int i2cAddress, int sampleRate, int gain)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 4) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 4) ;
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd         = fd ;
   node->data0      = sampleRate ;

--- a/wiringPi/mcp4802.c
+++ b/wiringPi/mcp4802.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stddef.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -64,10 +66,15 @@ int mcp4802Setup (const int pinBase, int spiChannel)
 {
   struct wiringPiNodeStruct *node ;
 
-  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  node = wiringPiNewNode (pinBase, 2) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 2) ;
+  if (wiringPiSPISetup (spiChannel, 1000000) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd          = spiChannel ;
   node->analogWrite = myAnalogWrite ;

--- a/wiringPi/pcf8574.c
+++ b/wiringPi/pcf8574.c
@@ -93,7 +93,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -111,10 +111,15 @@ int pcf8574Setup (const int pinBase, const int i2cAddress)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 8) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 8) ;
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd           = fd ;
   node->pinMode      = myPinMode ;

--- a/wiringPi/pcf8591.c
+++ b/wiringPi/pcf8591.c
@@ -77,10 +77,15 @@ int pcf8591Setup (const int pinBase, const int i2cAddress)
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  node = wiringPiNewNode (pinBase, 4) ;
+  if (node == NULL)
     return FALSE ;
 
-  node = wiringPiNewNode (pinBase, 4) ;
+  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  {
+    wiringPiRemoveNode(pinBase) ;
+    return FALSE ;
+  }
 
   node->fd          = fd ;
   node->analogRead  = myAnalogRead ;

--- a/wiringPi/pseudoPins.c
+++ b/wiringPi/pseudoPins.c
@@ -75,6 +75,8 @@ int pseudoPinsSetup (const int pinBase)
   void *ptr ;
 
   node = wiringPiNewNode (pinBase, PSEUDO_PINS) ;
+  if (node == NULL)
+    return FALSE ;
 
   node->fd = shm_open (SHARED_NAME, O_CREAT | O_RDWR, 0666) ;
 

--- a/wiringPi/rht03.c
+++ b/wiringPi/rht03.c
@@ -145,7 +145,7 @@ static int maxDetectRead (const int pin, unsigned char buffer [4])
   checksum &= 0xFF ;
 
 // See how long we took
-  
+
   gettimeofday (&now, NULL) ;
   timersub (&now, &then, &took) ;
 
@@ -177,7 +177,7 @@ static int myReadRHT03 (const int pin, int *temp, int *rh)
   unsigned char buffer [4] ;
 
 // Read ...
-  
+
   result = maxDetectRead (pin, buffer) ;
 
   if (!result)
@@ -240,10 +240,12 @@ int rht03Setup (const int pinBase, const int piPin)
 
   if ((piPin & PI_GPIO_MASK) != 0)	// Must be an on-board pin
     return FALSE ;
-  
+
 // 2 pins - temperature and humidity
 
   node = wiringPiNewNode (pinBase, 2) ;
+  if (node == NULL)
+    return FALSE ;
 
   node->fd         = piPin ;
   node->analogRead = myAnalogRead ;

--- a/wiringPi/sr595.c
+++ b/wiringPi/sr595.c
@@ -83,11 +83,13 @@ static void myDigitalWrite (struct wiringPiNodeStruct *node, int pin, int value)
  */
 
 int sr595Setup (const int pinBase, const int numPins,
-	const int dataPin, const int clockPin, const int latchPin) 
+	const int dataPin, const int clockPin, const int latchPin)
 {
   struct wiringPiNodeStruct *node ;
 
   node = wiringPiNewNode (pinBase, numPins) ;
+  if (node == NULL)
+    return FALSE ;
 
   node->data0           = dataPin ;
   node->data1           = clockPin ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1340,17 +1340,17 @@ struct wiringPiNodeStruct *wiringPiNewNode (int pinBase, int numPins)
 // Minimum pin base is 64
 
   if (pinBase < 64)
-    (void)wiringPiFailure (WPI_FATAL, "wiringPiNewNode: pinBase of %d is < 64\n", pinBase) ;
+    return NULL;
 
 // Check all pins in-case there is overlap:
 
   for (pin = pinBase ; pin < (pinBase + numPins) ; ++pin)
     if (wiringPiFindNode (pin) != NULL)
-      (void)wiringPiFailure (WPI_FATAL, "wiringPiNewNode: Pin %d overlaps with existing definition\n", pin) ;
+      return NULL;
 
   node = (struct wiringPiNodeStruct *)calloc (sizeof (struct wiringPiNodeStruct), 1) ;	// calloc zeros
   if (node == NULL)
-    (void)wiringPiFailure (WPI_FATAL, "wiringPiNewNode: Unable to allocate memory: %s\n", strerror (errno)) ;
+    (void)wiringPiFailure (WPI_ALMOST, "wiringPiNewNode: Unable to allocate memory: %s\n", strerror (errno)) ;
 
   node->pinBase          = pinBase ;
   node->pinMax           = pinBase + numPins - 1 ;
@@ -1411,7 +1411,7 @@ int wiringPiRemoveNode (int pinBase)
   //!@todo Run device specific code
 
   // Recover memory allocated to node
-  free(node);
+  free(node) ;
 
   return TRUE ;
 }

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1369,6 +1369,53 @@ struct wiringPiNodeStruct *wiringPiNewNode (int pinBase, int numPins)
   return node ;
 }
 
+/*
+ * wiringPiRemoveNode:
+ *	Remove an existing GPIO node from the wiringPi handling system
+ *********************************************************************************
+ */
+
+int wiringPiRemoveNode (int pinBase)
+{
+  struct wiringPiNodeStruct *node ;
+  struct wiringPiNodeStruct *nodePrevious ;
+
+// Don't try if there are no nodes in the tree or pinBase in naitive GPI range
+  if (wiringPiNodes == NULL || pinBase < 64)
+    return FALSE;
+
+// Find node
+  node = wiringPiFindNode (pinBase) ;
+  if (node == NULL)
+    return FALSE;
+
+// Remove node pointer from tree
+  if (node == wiringPiNodes)
+  {
+    wiringPiNodes = node->next;
+  }
+  else
+  {
+
+    nodePrevious = wiringPiNodes;
+
+    while (nodePrevious != NULL) {
+      if (nodePrevious->next == node) {
+        nodePrevious->next = node->next;
+        break;
+      }
+      nodePrevious = nodePrevious->next;
+    }
+  }
+
+  //!@todo Run device specific code
+
+  // Recover memory allocated to node
+  free(node);
+
+  return TRUE ;
+}
+
 
 #ifdef notYetReady
 /*

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -198,6 +198,7 @@ extern int wiringPiFailure (int fatal, const char *message, ...) ;
 
 extern struct wiringPiNodeStruct *wiringPiFindNode (int pin) ;
 extern struct wiringPiNodeStruct *wiringPiNewNode  (int pinBase, int numPins) ;
+extern int wiringPiRemoveNode  (int pinBase) ;
 
 extern void wiringPiVersion	(int *major, int *minor) ;
 extern int  wiringPiSetup       (void) ;


### PR DESCRIPTION
This pull request avoids fatal failure and subsequent exit from host application when attempting to add a device fails. This PR depends on https://github.com/WiringPi/WiringPi/pull/148 to allow adding the node before performing device specific setup then removing node if device specific setup fails. This is simpler and more consistent than trying to undo device specific setup, e.g. I2C may be configured by device but may already be in use by another device.

I observed that devices within devLib return 0 upon success whereas all other devices return TRUE. I have not changed this but it feels like that is an annomally.

I had to add `#include <stddef.h>` in some files to provide `NULL`. This felt more correct than referring to NULL by absolute value '0'.