### PR TITLE
Feature/150 isr with pin

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -2097,7 +2097,7 @@ int  _wiringPiISR (int pin, int mode, int withPin, void *function)
  *********************************************************************************
  */
 
-int wiringPiISR (int pin, int mode, void (*function)(void))
+int wiringPiISR (int pin, int mode, isr_function_t function)
 {
   return _wiringPiISR (pin, mode, -1, function);
 }
@@ -2110,7 +2110,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
  *********************************************************************************
  */
 
-int wiringPiISRX (int pin, int mode, void (*function)(int))
+int wiringPiISRX (int pin, int mode, isr_functionx_t function)
 {
   return _wiringPiISR (pin, mode, pin, function);
 }

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -329,8 +329,6 @@ static int sysFds [64] =
 
 // ISR Data
 
-typedef void isr_function_t();
-typedef void isr_function1_t();
 static void *isrFunctions [64] ;
 
 
@@ -1986,7 +1984,7 @@ static void *interruptHandler (UNU void *arg)
       if (withPin < 0)
         ((isr_function_t*) isrFunctions [myPin]) () ;
       else
-        ((isr_function1_t*) isrFunctions [myPin]) (withPin) ;
+        ((isr_functionx_t*) isrFunctions [myPin]) (withPin) ;
     }
   }
 

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -244,9 +244,12 @@ extern          void digitalWriteByte2   (int value) ;
 // Interrupts
 //	(Also Pi hardware specific)
 
+typedef void isr_function_t();
+typedef void isr_functionx_t();
+
 extern int  waitForInterrupt    (int pin, int mS) ;
-extern int  wiringPiISR         (int pin, int mode, void (*function)(void)) ;
-extern int  wiringPiISRX        (int pin, int mode, void (*function)(void)) ;
+extern int  wiringPiISR         (int pin, int mode, isr_function_t function);
+extern int  wiringPiISRX        (int pin, int mode, isr_functionx_t function);
 
 // Threads
 

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -245,7 +245,7 @@ extern          void digitalWriteByte2   (int value) ;
 //	(Also Pi hardware specific)
 
 typedef void isr_function_t();
-typedef void isr_functionx_t();
+typedef void isr_functionx_t(int);
 
 extern int  waitForInterrupt    (int pin, int mS) ;
 extern int  wiringPiISR         (int pin, int mode, isr_function_t function);

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -246,6 +246,7 @@ extern          void digitalWriteByte2   (int value) ;
 
 extern int  waitForInterrupt    (int pin, int mS) ;
 extern int  wiringPiISR         (int pin, int mode, void (*function)(void)) ;
+extern int  wiringPiISRX        (int pin, int mode, void (*function)(void)) ;
 
 // Threads
 


### PR DESCRIPTION
Adds a new function: `int  wiringPiISRX        (int pin, int mode, isr_functionx_t function);` which allows assigning an ISR to a pin with the callback defined as `void function(int pin)` passing the GPIO pin that triggered the interrupt. The old `wiringPiISR` function remains functional to avoid breaking the API.