### PR TITLE
Add more i2c busses to wiringPi

### DIFF
--- a/wiringPi/mcp23017.c
+++ b/wiringPi/mcp23017.c
@@ -158,7 +158,7 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
 
   if ((value & mask) == 0)
     return LOW ;
-  else 
+  else
     return HIGH ;
 }
 
@@ -170,13 +170,30 @@ static int myDigitalRead (struct wiringPiNodeStruct *node, int pin)
  *	user-defined pin base.
  *********************************************************************************
  */
-
 int mcp23017Setup (const int pinBase, const int i2cAddress)
+{
+    return mcp23017SetupDevice(pinBase, i2cAddress, -1);
+}
+
+
+/*
+ * mcp23017SetupDevice:
+ *	Create a new instance of an MCP23017 I2C GPIO interface. We know it
+ *	has 16 pins, so all we need to know here is the I2C address and the
+ *	user-defined pin base.
+ *  This function allows you to use extra I2C busses, if present.  This makes it
+ *  possible to have more than 8 MCP23017 devices in your HW if an I2C mux is used.
+ *  Backwards compatibility is guaranteed: existing code calls mcp23017Setup() which
+ *  will call mcp23017SetupDevice() with dev == -1, resulting in exactly the same
+ *  behaviour as before.
+ *********************************************************************************
+ */
+int mcp23017SetupDevice (const int pinBase, const int i2cAddress, const int dev)
 {
   int fd ;
   struct wiringPiNodeStruct *node ;
 
-  if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
+  if ((fd = wiringPiI2CSetupDevice (i2cAddress, dev)) < 0)
     return FALSE ;
 
   wiringPiI2CWriteReg8 (fd, MCP23x17_IOCON, IOCON_INIT) ;

--- a/wiringPi/mcp23017.h
+++ b/wiringPi/mcp23017.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+extern int mcp23017SetupDevice (const int pinBase, const int i2cAddress, const int device) ;
 extern int mcp23017Setup (const int pinBase, const int i2cAddress) ;
 
 #ifdef __cplusplus

--- a/wiringPi/wiringPiI2C.h
+++ b/wiringPi/wiringPiI2C.h
@@ -36,6 +36,7 @@ extern int wiringPiI2CWriteReg16     (int fd, int reg, int data) ;
 
 extern int wiringPiI2CSetupInterface (const char *device, int devId) ;
 extern int wiringPiI2CSetup          (const int devId) ;
+extern int wiringPiI2CSetupDevice    (const int devId, int dev) ;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, wiringPi is limited to only 2 I2C busses, based on the Raspberry Pi revision number: 
- if revision == 1, `/dev/i2c-0` is used
- in all other cases, `/dev/i2c-1` is used.

However, the Linux kernel has built-in functionality to use an I2C MUX, such as the PCA9548 (1-to8 I2C bus).  If activated (through a modification in the `/boot/config.txt` file) the Raspberry Pi will "sense" at startup if such device is connected or not using the default I2C MUX address `0x70` (can also be changed in the `/boot/config.txt` file).
When present, there will be (in the case of a PCA9548) 8 extra I2C busses available: `/dev/i2c-11 ... /dev/i2c-18`.

This commit allows the use of those extra I2C busses, currently only for the MCP23017.  There are 2 extra methods added to allow other bus usage than the default ones.  The extra methods are:

- `mcp23017SetupDevice(const int pinBase, const int i2cAddress, const int dev)`
The extra third parameter allows the user to choose another I2C bus than the default one.
- `wiringPiI2CSetupDevice(const int devId, const int dev)`
The extra second parameter allows the user to choose another I2C bus than the default one.

Backwards compatibility is guaranteed: existing code is still calling the existing functions `mcp23017Setup()` and `wiringPiI2CSetup()`.  They will reroute the incoming call to the newly added functions with the value of the extra parameter set to -1.
This will make sure that the previous behaviour is maintained.

Can also be applied to the MCP23008 later on.  
