### PR TITLE
Replacing PWM pulse delay's hardcoded value from 100 to macro PULSE_TIME

### DIFF
--- a/wiringPi/softPwm.c
+++ b/wiringPi/softPwm.c
@@ -87,11 +87,11 @@ static void *softPwmThread (void *arg)
 
     if (mark != 0)
       digitalWrite (pin, HIGH) ;
-    delayMicroseconds (mark * 100) ;
+    delayMicroseconds (mark * PULSE_TIME) ;
 
     if (space != 0)
       digitalWrite (pin, LOW) ;
-    delayMicroseconds (space * 100) ;
+    delayMicroseconds (space * PULSE_TIME) ;
   }
 
   return NULL ;


### PR DESCRIPTION
pwm create function is currently using hardcoded pulse time of 100us. Changing this to define PULSE_TIME for ease of change and to avoid confusion