### PR TITLE
linked discussions page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ wiringPi has been wrapped for multiple languages:
 
 Please use the [issue system](https://github.com/WiringPi/WiringPi/issues) of GitHub.
 
+If you're not sure whether to create an issue or not, please engage in [discussions](https://github.com/WiringPi/WiringPi/discussions)!
+
 Please do not email Gordon or @Gadgetoid.
 
 Please don't email GC2 for reporting issues, you might [contact us](mailto:wiringpi@gc2.at) for anything that's not meant for the public.


### PR DESCRIPTION
I've re-enabled discussions (after purging all old content), imo we should link it in the README.