### PR TITLE
fix some typos, improve error message

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -857,7 +857,7 @@ static void usingGpioMemCheck (const char *what)
 void PrintSystemStdErr () {
   struct utsname sys_info;
   if (uname(&sys_info) == 0) {
-    fprintf (stderr, "      wiringpi    : %d.%d\n", VERSION_MAJOR, VERSION_MINOR);
+    fprintf (stderr, "      WiringPi    : %d.%d\n", VERSION_MAJOR, VERSION_MINOR);
     fprintf (stderr, "      system name : %s\n", sys_info.sysname);
     //fprintf (stderr, "  node name   : %s\n", sys_info.nodename);
     fprintf (stderr, "      release     : %s\n", sys_info.release);

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -857,12 +857,12 @@ static void usingGpioMemCheck (const char *what)
 void PrintSystemStdErr () {
   struct utsname sys_info;
   if (uname(&sys_info) == 0) {
-    fprintf (stderr, "      wiringpi    = %d.%d\n", VERSION_MAJOR, VERSION_MINOR);
-    fprintf (stderr, "      system name = %s\n", sys_info.sysname);
-    //fprintf (stderr, "  node name   = %s\n", sys_info.nodename);
-    fprintf (stderr, "      release     = %s\n", sys_info.release);
-    fprintf (stderr, "      version     = %s\n", sys_info.version);
-    fprintf (stderr, "      machine     = %s\n", sys_info.machine);
+    fprintf (stderr, "      wiringpi    : %d.%d\n", VERSION_MAJOR, VERSION_MINOR);
+    fprintf (stderr, "      system name : %s\n", sys_info.sysname);
+    //fprintf (stderr, "  node name   : %s\n", sys_info.nodename);
+    fprintf (stderr, "      release     : %s\n", sys_info.release);
+    fprintf (stderr, "      version     : %s\n", sys_info.version);
+    fprintf (stderr, "      machine     : %s\n", sys_info.machine);
     if (strstr(sys_info.machine, "arm") == NULL && strstr(sys_info.machine, "aarch")==NULL) {
       fprintf (stderr, " -> This is not an ARM architecture; it cannot be a Raspberry Pi.\n") ;
     }
@@ -2813,7 +2813,7 @@ int wiringPiSetupPhys (void)
 int wiringPiSetupSys (void)
 {
   piFunctionOops("wiringPiSetupSys",
-   "use wringpi 3.1 (last version with GPIO Sysfs interface)",
+   "use WiringPi 3.1 (last version with GPIO Sysfs interface)",
    "https://www.kernel.org/doc/html/v5.5/admin-guide/gpio/sysfs.html");
 
   return 0 ;


### PR DESCRIPTION
```
gpio: Unable to open GPIO direction interface for pin 24: No such file or directory
Oops: Function wiringPiSetupSys is not supported
      wiringpi    = 3.2
      system name = Linux
      release     = 6.6.20+rpt-rpi-v7
      version     = #1 SMP Raspbian 1:6.6.20-1+rpt1 (2024-03-07)
      machine     = armv7l
 -> Please use wringpi 3.1 (last version with GPIO Sysfs interface)
 ```
 =>
 ```
gpio: Unable to open GPIO direction interface for pin 24: No such file or directory
Oops: Function wiringPiSetupSys is not supported
      wiringpi    : 3.2
      system name : Linux
      release     : 6.6.20+rpt-rpi-v7
      version     : #1 SMP Raspbian 1:6.6.20-1+rpt1 (2024-03-07)
      machine     : armv7l
 -> Please use WiringPi 3.1 (last version with GPIO Sysfs interface)
 ```