### PR TITLE
Fixed warnings and removed unused function

### DIFF
--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -290,13 +290,33 @@ static void doLoad (int argc, char *argv [])
   if (!moduleLoaded (module1))
   {
     sprintf (cmd, "%s %s%s", findExecutable (MODPROBE), module1, args1) ;
-    system (cmd) ;
+    int ret = system(cmd);
+    if (ret == -1) {
+      perror("Error executing command");
+    } else if (WIFEXITED(ret)) {
+      int exit_status = WEXITSTATUS(ret);
+      if (exit_status != 0) {
+        fprintf(stderr, "Command failed with exit status %d\n", exit_status);
+      }
+    } else {
+      fprintf(stderr, "Command terminated by signal\n");
+    }
   }
 
   if (!moduleLoaded (module2))
   {
     sprintf (cmd, "%s %s%s", findExecutable (MODPROBE), module2, args2) ;
-    system (cmd) ;
+    int ret = system(cmd);
+    if (ret == -1) {
+      perror("Error executing command");
+    } else if (WIFEXITED(ret)) {
+      int exit_status = WEXITSTATUS(ret);
+      if (exit_status != 0) {
+        fprintf(stderr, "Command failed with exit status %d\n", exit_status);
+      }
+    } else {
+      fprintf(stderr, "Command terminated by signal\n");
+    }
   }
 
   if (!moduleLoaded (module2))
@@ -350,13 +370,33 @@ static void doUnLoad (int argc, char *argv [])
   if (moduleLoaded (module1))
   {
     sprintf (cmd, "%s %s", findExecutable (RMMOD), module1) ;
-    system (cmd) ;
+    int ret = system(cmd);
+    if (ret == -1) {
+      perror("Error executing command");
+    } else if (WIFEXITED(ret)) {
+      int exit_status = WEXITSTATUS(ret);
+      if (exit_status != 0) {
+        fprintf(stderr, "Command failed with exit status %d\n", exit_status);
+      }
+    } else {
+      fprintf(stderr, "Command terminated by signal\n");
+    }
   }
 
   if (moduleLoaded (module2))
   {
     sprintf (cmd, "%s %s", findExecutable (RMMOD), module2) ;
-    system (cmd) ;
+    int ret = system(cmd);
+    if (ret == -1) {
+      perror("Error executing command");
+    } else if (WIFEXITED(ret)) {
+      int exit_status = WEXITSTATUS(ret);
+      if (exit_status != 0) {
+        fprintf(stderr, "Command failed with exit status %d\n", exit_status);
+      }
+    } else {
+      fprintf(stderr, "Command terminated by signal\n");
+    }
   }
 }
 
@@ -562,14 +602,14 @@ static volatile int globalCounter ;
 
 void printgpioflush(const char* text) {
   if (gpioDebug) {
-    printf(text);
+    printf("%s", text); 
     fflush(stdout);
   }
 }
 
 void printgpio(const char* text) {
   if (gpioDebug) {
-    printf(text);
+    printf("%s", text);
     fflush(stdout);
   }
 }
@@ -1371,7 +1411,10 @@ static void doVersion (char *argv [])
   {
     if ((fd = fopen ("/proc/device-tree/model", "r")) != NULL)
     {
-      fgets (name, 80, fd) ;
+      if (fgets(name, sizeof(name), fd) == NULL) {
+        // Handle error or end of file condition
+        perror("Error reading /proc/device-tree/model");
+      }
       fclose (fd) ;
       printf ("  *--> %s\n", name) ;
     }

--- a/wiringPi/mcp3422.c
+++ b/wiringPi/mcp3422.c
@@ -43,15 +43,20 @@
  *********************************************************************************
  */
 
-void waitForConversion (int fd, unsigned char *buffer, int n)
+void waitForConversion(int fd, unsigned char *buffer, int n)
 {
-  for (;;)
-  {
-    read (fd, buffer, n) ;
-    if ((buffer [n-1] & 0x80) == 0)
-      break ;
-    delay (1) ;
-  }
+    for (;;) {
+        ssize_t bytes_read = read(fd, buffer, n);
+        if (bytes_read != n) {
+            perror("Error reading from file descriptor");
+            return;
+        }
+        
+        if ((buffer[n - 1] & 0x80) == 0)
+            break;
+        
+        delay(1);
+    }
 }
 
 /*

--- a/wiringPi/pcf8591.c
+++ b/wiringPi/pcf8591.c
@@ -24,6 +24,7 @@
  */
 
 #include <unistd.h>
+#include <stdio.h>
 
 #include "wiringPi.h"
 #include "wiringPiI2C.h"
@@ -41,7 +42,10 @@ static void myAnalogWrite (struct wiringPiNodeStruct *node, UNU int pin, int val
   unsigned char b [2] ;
   b [0] = 0x40 ;
   b [1] = value & 0xFF ;
-  write (node->fd, b, 2) ;
+  ssize_t bytes_written = write(node->fd, b, 2);
+  if (bytes_written != 2) {
+      perror("Error writing to file descriptor");
+  }
 }
 
 

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -536,31 +536,6 @@ const int _0v=-1;
 const int _3v=-1;
 
 
-static int physToSysGPIOPi5 [41] =
-{
-   -1,		// 0
-  _3v, _5v,	// 1, 2
-  401, _5v,
-  402, _0v,
-  403, 413,
-  _0v, 414,
-  416, 417,
-  426, _0v,
-  421, 422,
-  _3v, 423,
-  409, _0v,
-  408, 424,
-  410, 407,
-  _0v, 406,
-  399, 400,
-  404, _0v,
-  405, 411,
-  412, _0v,
-  418, 415,
-  425, 419,
-  _0v, 420, //39, 40
-} ;
-
 int GPIOToSysFS(const int pin) {
   int sysfspin =  pin;
   if (RaspberryPiModel<0) { //need to detect pi model

--- a/wiringPi/wiringSerial.c
+++ b/wiringPi/wiringSerial.c
@@ -153,9 +153,12 @@ void serialClose (const int fd)
  *********************************************************************************
  */
 
-void serialPutchar (const int fd, const unsigned char c)
+void serialPutchar(const int fd, const unsigned char c)
 {
-  write (fd, &c, 1) ;
+    ssize_t bytes_written = write(fd, &c, 1);
+    if (bytes_written != 1) {
+        perror("Error writing to file descriptor");
+    }
 }
 
 
@@ -165,9 +168,13 @@ void serialPutchar (const int fd, const unsigned char c)
  *********************************************************************************
  */
 
-void serialPuts (const int fd, const char *s)
+void serialPuts(const int fd, const char *s)
 {
-  write (fd, s, strlen (s)) ;
+    size_t len = strlen(s);
+    ssize_t bytes_written = write(fd, s, len);
+    if (bytes_written != (ssize_t)len) {
+        perror("Error writing to file descriptor");
+    }
 }
 
 /*


### PR DESCRIPTION
Fixed warnings in:
gpio/gpio.c
wiringPi/mcp3422.c
wiringPi/pcf8591.c
wiringPi/pseudoPins.c
wiringPi/wiringSerial.c

removed unused variable physToSysGPIOPi5 in wiringPi/wiringPi.c