### PR TITLE
support bookworm

### DIFF
--- a/wiringPi/wiringPiLegacy.c
+++ b/wiringPi/wiringPiLegacy.c
@@ -80,7 +80,11 @@ int piGpioLayoutLegacy (void)
     if (strncmp (line, "Hardware", 8) == 0)
       break ;
 
-  if (strncmp (line, "Hardware", 8) != 0)
+  FILE * modelFd;
+  
+  if ((strncmp (line, "Hardware", 8) != 0) && 
+	  (((modelFd = fopen ("/sys/firmware/devicetree/base/model", "r")) != NULL) ||
+		  (fgets (line, 64, modelFd) != NULL)))
     piGpioLayoutOops ("No \"Hardware\" line") ;
 
   if (wiringPiDebug)


### PR DESCRIPTION
    No Hardware line in /proc/cpuinfo for Bookworm (especially for Raspberry Pi 4 or later), which cause gpio failure.
    Add trying to read model name from /sys/firmware/devicetree/base/model for model name when failed to fetch Hardware line from /proc/cpuinfo