### PR TITLE
Improve CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 project(WiringPiLib)
 
+# Read version from version.h
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/version.h" WIRINGPI_VERSION)
+string(REGEX REPLACE ".*VERSION \"([0-9]+.[0-9]+)\".*" "\\1" WIRINGPI_VERSION "${WIRINGPI_VERSION}")
+string(REGEX REPLACE "([0-9]+)\..*" "\\1" WIRINGPI_SOVERSION "${WIRINGPI_VERSION}")
+
 # Include subdirectories
 add_subdirectory(devLib)
 add_subdirectory(gpio)

--- a/devLib/CMakeLists.txt
+++ b/devLib/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat=2 -Winline -pipe")
 add_library(wiringPiDev SHARED ${SRC})
 
 # Set the library version
-set_target_properties(wiringPiDev PROPERTIES VERSION ${VERSION} SOVERSION ${WIRINGPI_SONAME_SUFFIX})
+set_target_properties(wiringPiDev PROPERTIES VERSION ${WIRINGPI_VERSION} SOVERSION ${WIRINGPI_SOVERSION})
 
 # Install headers
 install(FILES ${HEADERS} DESTINATION include)

--- a/devLib/CMakeLists.txt
+++ b/devLib/CMakeLists.txt
@@ -22,7 +22,7 @@ set(HEADERS
 )
 
 # Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat=2 -Winline -pipe -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat=2 -Winline -pipe")
 
 # Add the library target
 add_library(wiringPiDev SHARED ${SRC})

--- a/devLib/CMakeLists.txt
+++ b/devLib/CMakeLists.txt
@@ -27,6 +27,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat=2 -Winline -pipe")
 # Add the library target
 add_library(wiringPiDev SHARED ${SRC})
 
+target_include_directories(wiringPiDev PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(wiringPiDev PRIVATE wiringPi)
+
 # Set the library version
 set_target_properties(wiringPiDev PROPERTIES VERSION ${WIRINGPI_VERSION} SOVERSION ${WIRINGPI_SOVERSION})
 

--- a/gpio/CMakeLists.txt
+++ b/gpio/CMakeLists.txt
@@ -20,12 +20,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 # Add the executable target
 add_executable(gpio ${SRC})
 
-# Find the required libraries
-find_library(WIRINGPI_LIB wiringPi)
-find_library(WIRINGPI_DEV_LIB wiringPiDev)
-
 # Link the required libraries
-target_link_libraries(gpio ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} Threads::Threads m PkgConfig::libcrypt)
+target_link_libraries(gpio wiringPi wiringPiDev Threads::Threads m PkgConfig::libcrypt)
 
 # Install the executable
 install(TARGETS gpio DESTINATION bin)

--- a/gpio/CMakeLists.txt
+++ b/gpio/CMakeLists.txt
@@ -6,6 +6,8 @@ project(gpio)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libcrypt REQUIRED IMPORTED_TARGET)
 
+find_package(Threads REQUIRED)
+
 # Source files
 set(SRC
     gpio.c
@@ -23,7 +25,7 @@ find_library(WIRINGPI_LIB wiringPi)
 find_library(WIRINGPI_DEV_LIB wiringPiDev)
 
 # Link the required libraries
-target_link_libraries(gpio ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} pthread rt m PkgConfig::libcrypt)
+target_link_libraries(gpio ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} Threads::Threads m PkgConfig::libcrypt)
 
 # Install the executable
 install(TARGETS gpio DESTINATION bin)

--- a/gpio/CMakeLists.txt
+++ b/gpio/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(gpio)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libcrypt REQUIRED IMPORTED_TARGET)
+
 # Source files
 set(SRC
     gpio.c
@@ -20,7 +23,7 @@ find_library(WIRINGPI_LIB wiringPi)
 find_library(WIRINGPI_DEV_LIB wiringPiDev)
 
 # Link the required libraries
-target_link_libraries(gpio ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} pthread rt m crypt)
+target_link_libraries(gpio ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} pthread rt m PkgConfig::libcrypt)
 
 # Install the executable
 install(TARGETS gpio DESTINATION bin)

--- a/wiringPi/CMakeLists.txt
+++ b/wiringPi/CMakeLists.txt
@@ -44,18 +44,12 @@ set(HEADERS
 )
 # Compiler flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Winline -pipe -Wformat-security")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-soname,libwiringPi.so${WIRINGPI_SONAME_SUFFIX}")
-
-# Read version from version.h
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../version.h" VERSION)
-string(REGEX REPLACE ".*VERSION \"([0-9]+.[0-9]+)\".*" "\\1" VERSION "${VERSION}")
 
 # Add the library target
 add_library(wiringPi SHARED ${SRC})
 
 # Set the library version
-set(WIRINGPI_SONAME_SUFFIX "1")
-set_target_properties(wiringPi PROPERTIES VERSION ${VERSION} SOVERSION ${WIRINGPI_SONAME_SUFFIX})
+set_target_properties(wiringPi PROPERTIES VERSION ${WIRINGPI_VERSION} SOVERSION ${WIRINGPI_SOVERSION})
 target_include_directories(wiringPi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Add -lm to link with the math library

--- a/wiringPi/CMakeLists.txt
+++ b/wiringPi/CMakeLists.txt
@@ -43,7 +43,7 @@ set(HEADERS
     wpiExtensions.h
 )
 # Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Winline -pipe -fPIC -Wformat-security")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Winline -pipe -Wformat-security")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-soname,libwiringPi.so${WIRINGPI_SONAME_SUFFIX}")
 
 # Read version from version.h


### PR DESCRIPTION
Hi,

I consider adding a recipe in Yocto project to integrate WiringPi, possibly back in [meta-raspberrypi](https://github.com/agherzan/meta-raspberrypi). The CMake build really seems to be the simplest way to do so.
Consequently, I made some modifications in, especially for dependency management and shared library version.

