### PR TITLE
[cleanup] Remove extra indents before `if` followed by `if else`

### DIFF
--- a/devLib/lcd128x64.c
+++ b/devLib/lcd128x64.c
@@ -370,7 +370,7 @@ void lcd128x64rectangle (int x1, int y1, int x2, int y2, int colour, int filled)
 
   if (filled)
   {
-    /**/ if (x1 == x2)
+    if      (x1 == x2)
       lcd128x64line (x1, y1, x2, y2, colour) ;
     else if (x1 < x2)
       for (x = x1 ; x <= x2 ; ++x)

--- a/devLib/piGlow.c
+++ b/devLib/piGlow.c
@@ -47,12 +47,9 @@ void piGlow1 (const int leg, const int ring, const int intensity)
   if ((leg  < 0) || (leg  > 2)) return ;
   if ((ring < 0) || (ring > 5)) return ;
 
-  /**/ if (leg == 0)
-    legLeds = leg0 ;
-  else if (leg == 1)
-    legLeds = leg1 ;
-  else
-    legLeds = leg2 ;
+  if      (leg == 0) { legLeds = leg0 ; }
+  else if (leg == 1) { legLeds = leg1 ; }
+  else               { legLeds = leg2 ; }
 
   analogWrite (PIGLOW_BASE + legLeds [ring], intensity) ;
 }
@@ -71,12 +68,9 @@ void piGlowLeg (const int leg, const int intensity)
   if ((leg < 0) || (leg > 2))
     return ;
 
-  /**/ if (leg == 0)
-    legLeds = leg0 ;
-  else if (leg == 1)
-    legLeds = leg1 ;
-  else
-    legLeds = leg2 ;
+  if      (leg == 0) { legLeds = leg0 ; }
+  else if (leg == 1) { legLeds = leg1 ; }
+  else               { legLeds = leg2 ; }
 
   for (i = 0 ; i < 6 ; ++i)
     analogWrite (PIGLOW_BASE + legLeds [i], intensity) ;

--- a/devLib/scrollPhat.c
+++ b/devLib/scrollPhat.c
@@ -210,19 +210,21 @@ void scrollPhatRectangle (int x1, int y1, int x2, int y2, int colour, int filled
 {
   register int x ;
 
-  if (filled)
-  {
-    /**/ if (x1 == x2)
+  if (filled) {
+    if (x1 == x2) {
       scrollPhatLine (x1, y1, x2, y2, colour) ;
-    else if (x1 < x2)
-      for (x = x1 ; x <= x2 ; ++x)
-	scrollPhatLine (x, y1, x, y2, colour) ;
-    else
-      for (x = x2 ; x <= x1 ; ++x)
-	scrollPhatLine (x, y1, x, y2, colour) ;
-  }
-  else
-  {
+    }
+    else if (x1 < x2) {
+      for (x = x1 ; x <= x2 ; ++x) {
+        scrollPhatLine (x, y1, x, y2, colour) ;
+      }
+    }
+    else {
+      for (x = x2 ; x <= x1 ; ++x) {
+        scrollPhatLine (x, y1, x, y2, colour) ;
+      }
+    }
+  } else {
     scrollPhatLine   (x1, y1, x2, y1, colour) ;
     scrollPhatLineTo (x2, y2, colour) ;
     scrollPhatLineTo (x1, y2, colour) ;

--- a/examples/Gertboard/7segments.c
+++ b/examples/Gertboard/7segments.c
@@ -91,7 +91,7 @@ PI_THREAD (displayDigits)
       for (segment = 0 ; segment < 7 ; ++segment)
       {
 	d = toupper (display [digit]) ;
-	/**/ if ((d >= '0') && (d <= '9'))	// Digit
+	if      ((d >= '0') && (d <= '9'))	// Digit
 	  index = d - '0' ;
 	else if ((d >= 'A') && (d <= 'F'))	// Hex
 	  index = d - 'A' + 10 ;

--- a/examples/PiGlow/piglow.c
+++ b/examples/PiGlow/piglow.c
@@ -97,7 +97,7 @@ int main (int argc, char *argv [])
   {
     percent = getPercent (argv [2]) ;
 
-    /**/ if (strcasecmp (argv [1], "red") == 0)
+    if      (strcasecmp (argv [1], "red") == 0)
       piGlowRing (PIGLOW_RED, percent) ;
     else if (strcasecmp (argv [1], "yellow") == 0)
       piGlowRing (PIGLOW_YELLOW, percent) ;
@@ -122,7 +122,7 @@ int main (int argc, char *argv [])
 
   if (argc == 4)
   {
-    /**/ if (strcasecmp (argv [1], "leg") == 0)
+    if (strcasecmp (argv [1], "leg") == 0)
     {
       leg = atoi (argv [2]) ;
       if ((leg < 0) || (leg > 2))

--- a/examples/ds1302.c
+++ b/examples/ds1302.c
@@ -205,7 +205,7 @@ int main (int argc, char *argv [])
 
   if (argc == 2)
   {
-    /**/ if (strcmp (argv [1], "-slc") == 0)
+    if      (strcmp (argv [1], "-slc") == 0)
       return setLinuxClock () ;
     else if (strcmp (argv [1], "-sdsc") == 0)
       return setDSclock () ;

--- a/examples/scrollPhat/scphat.c
+++ b/examples/scrollPhat/scphat.c
@@ -209,7 +209,7 @@ int main (int argc, char *argv [])
   while (arg != argc)
   {
     command = argv [arg] ;
-    /**/ if (strcasecmp (command, "clear")  == 0) arg += doClear  () ;
+    if      (strcasecmp (command, "clear")  == 0) arg += doClear  () ;
     else if (strcasecmp (command, "cls")    == 0) arg += doClear  () ;
     else if (strcasecmp (command, "bright") == 0) arg += doBright (arg, argc, argv) ;
     else if (strcasecmp (command, "plot")   == 0) arg += doPlot   (arg, argc, argv) ;

--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -370,7 +370,7 @@ void doMode (int argc, char *argv [])
 
   mode = argv [3] ;
 
-  /**/ if (strcasecmp (mode, "in")      == 0) pinMode         (pin, INPUT) ;
+  if      (strcasecmp (mode, "in")      == 0) pinMode         (pin, INPUT) ;
   else if (strcasecmp (mode, "input")   == 0) pinMode         (pin, INPUT) ;
   else if (strcasecmp (mode, "out")     == 0) pinMode         (pin, OUTPUT) ;
   else if (strcasecmp (mode, "output")  == 0) pinMode         (pin, OUTPUT) ;
@@ -602,14 +602,14 @@ static void doWrite (int argc, char *argv [])
 
   pin = atoi (argv [2]) ;
 
-  /**/ if ((strcasecmp (argv [3], "up") == 0) || (strcasecmp (argv [3], "on") == 0))
+  if      ((strcasecmp (argv [3], "up") == 0) || (strcasecmp (argv [3], "on") == 0))
     val = 1 ;
   else if ((strcasecmp (argv [3], "down") == 0) || (strcasecmp (argv [3], "off") == 0))
     val = 0 ;
   else
     val = atoi (argv [3]) ;
 
-  /**/ if (val == 0)
+  if (val == 0)
     digitalWrite (pin, LOW) ;
   else
     digitalWrite (pin, HIGH) ;
@@ -1063,7 +1063,7 @@ int main (int argc, char *argv [])
 
 // Initial test for /sys/class/gpio operations:  --> deprecated, empty but still there
 
-  /**/ if (strcasecmp (argv [1], "exports"    ) == 0)	{ SYSFS_DEPRECATED(argv[0]);	return 0 ; }
+  if      (strcasecmp (argv [1], "exports"    ) == 0)	{ SYSFS_DEPRECATED(argv[0]);	return 0 ; }
   else if (strcasecmp (argv [1], "export"     ) == 0)	{ SYSFS_DEPRECATED(argv[0]);	return 0 ; }
   else if (strcasecmp (argv [1], "edge"       ) == 0)	{ SYSFS_DEPRECATED(argv[0]);	return 0 ; }
   else if (strcasecmp (argv [1], "unexport"   ) == 0)	{ SYSFS_DEPRECATED(argv[0]);	return 0 ; }
@@ -1094,7 +1094,7 @@ int main (int argc, char *argv [])
 
 // Check for -g argument
 
-  /**/ if (strcasecmp (argv [1], "-g") == 0)
+  if (strcasecmp (argv [1], "-g") == 0)
   {
     wiringPiSetupGpio () ;
 
@@ -1180,7 +1180,7 @@ int main (int argc, char *argv [])
 
 // Core wiringPi functions
 
-  /**/ if (strcasecmp (argv [1], "mode"   ) == 0) doMode      (argc, argv) ;
+  if      (strcasecmp (argv [1], "mode"   ) == 0) doMode      (argc, argv) ;
   else if (strcasecmp (argv [1], "read"   ) == 0) doRead      (argc, argv) ;
   else if (strcasecmp (argv [1], "write"  ) == 0) doWrite     (argc, argv) ;
   else if (strcasecmp (argv [1], "pwm"    ) == 0) doPwm       (argc, argv) ;

--- a/gpio/readall.c
+++ b/gpio/readall.c
@@ -183,7 +183,7 @@ static void readallPhys (int physPin)
     printf (" |      |  ") ;
   else
   {
-    /**/ if (wpMode == WPI_MODE_GPIO)
+    if      (wpMode == WPI_MODE_GPIO)
       pin = physPinToGpio (physPin) ;
     else if (wpMode == WPI_MODE_PHYS)
       pin = physPin ;
@@ -206,7 +206,7 @@ static void readallPhys (int physPin)
     printf (" |   |     ") ;
   else
   {
-    /**/ if (wpMode == WPI_MODE_GPIO)
+    if      (wpMode == WPI_MODE_GPIO)
       pin = physPinToGpio (physPin) ;
     else if (wpMode == WPI_MODE_PHYS)
       pin = physPin ;
@@ -380,7 +380,7 @@ void doReadall (void)
 
   piBoardId (&model, &rev, &mem, &maker, &overVolted) ;
 
-  /**/ if ((model == PI_MODEL_A) || (model == PI_MODEL_B))
+  if      ((model == PI_MODEL_A) || (model == PI_MODEL_B))
     abReadall (model, rev) ;
   else if ((model == PI_MODEL_BP) || (model == PI_MODEL_AP) ||
 	(model == PI_MODEL_2)    ||

--- a/wiringPi/ads1115.c
+++ b/wiringPi/ads1115.c
@@ -252,7 +252,7 @@ static void myAnalogWrite (struct wiringPiNodeStruct *node, int pin, int data)
 
   reg = chan + 2 ;
 
-  /**/ if (data < -32767)
+  if      (data < -32767)
     ndata = -32767 ;
   else if (data > 32767)
     ndata = 32767 ;

--- a/wiringPi/bmp180.c
+++ b/wiringPi/bmp180.c
@@ -164,7 +164,7 @@ static int myAnalogRead (struct wiringPiNodeStruct *node, int pin)
 
   bmp180ReadTempPress (node->fd) ;
 
-  /**/ if (chan == 0)	// Read Temperature
+  if      (chan == 0)	// Read Temperature
     return cTemp ;
   else if (chan == 1)	// Pressure
     return cPress ;

--- a/wiringPi/drcSerial.c
+++ b/wiringPi/drcSerial.c
@@ -41,7 +41,7 @@
 
 static void myPinMode (struct wiringPiNodeStruct *node, int pin, int mode)
 {
-  /**/ if (mode == OUTPUT)
+  if      (mode == OUTPUT)
     serialPutchar (node->fd, 'o') ;       // Input
   else if (mode == PWM_OUTPUT)
     serialPutchar (node->fd, 'p') ;       // PWM
@@ -66,7 +66,7 @@ static void myPullUpDnControl (struct wiringPiNodeStruct *node, int pin, int mod
   serialPutchar (node->fd, 'i' ) ;
   serialPutchar (node->fd, pin - node->pinBase) ;
 
-  /**/ if (mode == PUD_UP)
+  if      (mode == PUD_UP)
   {
     serialPutchar (node->fd, '1') ;
     serialPutchar (node->fd, pin - node->pinBase) ;

--- a/wiringPi/htu21d.c
+++ b/wiringPi/htu21d.c
@@ -59,7 +59,7 @@ static int myAnalogRead (struct wiringPiNodeStruct *node, int pin)
   double   fTemp, fHumid ;
   int      cTemp, cHumid ;
 
-  /**/ if (chan == 0)	// Read Temperature
+  if (chan == 0)  // Read Temperature
   {
 
 // Send read temperature command:

--- a/wiringPi/softPwm.c
+++ b/wiringPi/softPwm.c
@@ -108,10 +108,8 @@ void softPwmWrite (int pin, int value)
 {
   if (pin < MAX_PINS)
   {
-    /**/ if (value < 0)
-      value = 0 ;
-    else if (value > range [pin])
-      value = range [pin] ;
+    if      (value < 0)           { value = 0 ; }
+    else if (value > range [pin]) { value = range [pin] ; }
 
     marks [pin] = value ;
   }

--- a/wiringPi/softServo.c
+++ b/wiringPi/softServo.c
@@ -165,7 +165,7 @@ void softServoWrite (int servoPin, int value)
 
   servoPin &= 63 ;
 
-  /**/ if (value < -250)
+  if      (value < -250)
     value = -250 ;
   else if (value > 1250)
     value = 1250 ;

--- a/wiringPi/softTone.c
+++ b/wiringPi/softTone.c
@@ -92,7 +92,7 @@ void softToneWrite (int pin, int freq)
 {
   pin &= 63 ;
 
-  /**/ if (freq < 0)
+  if      (freq < 0)
     freq = 0 ;
   else if (freq > 5000)	// Max 5KHz
     freq = 5000 ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1217,37 +1217,37 @@ void piBoardId (int *model, int *rev, int *mem, int *maker, int *warranty)
 
 // Fill out the replys as appropriate
     RaspberryPiLayout = GPIO_LAYOUT_DEFAULT ; //default
-    /**/ if (strcmp (c, "0002") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1   ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; RaspberryPiLayout = GPIO_LAYOUT_PI1_REV1; }
-    else if (strcmp (c, "0003") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; RaspberryPiLayout = GPIO_LAYOUT_PI1_REV1; }
+    if      (strcmp (c, "0002") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1   ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; RaspberryPiLayout = GPIO_LAYOUT_PI1_REV1; }
+    else if (strcmp (c, "0003") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; RaspberryPiLayout = GPIO_LAYOUT_PI1_REV1; }
 
-    else if (strcmp (c, "0004") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "0005") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; }
-    else if (strcmp (c, "0006") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "0004") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0005") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; }
+    else if (strcmp (c, "0006") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else if (strcmp (c, "0007") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; }
-    else if (strcmp (c, "0008") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_SONY ;  ; }
-    else if (strcmp (c, "0009") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "0007") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; }
+    else if (strcmp (c, "0008") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0009") == 0) { *model = PI_MODEL_A  ; *rev = PI_VERSION_1_2 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else if (strcmp (c, "000d") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN  ; }
-    else if (strcmp (c, "000e") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "000f") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "000d") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN ; }
+    else if (strcmp (c, "000e") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "000f") == 0) { *model = PI_MODEL_B  ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else if (strcmp (c, "0010") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "0013") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EMBEST  ; }
-    else if (strcmp (c, "0016") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "0019") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "0010") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0013") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EMBEST ; }
+    else if (strcmp (c, "0016") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0019") == 0) { *model = PI_MODEL_BP ; *rev = PI_VERSION_1_2 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else if (strcmp (c, "0011") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "0014") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EMBEST  ; }
-    else if (strcmp (c, "0017") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "001a") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "0011") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0014") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EMBEST ; }
+    else if (strcmp (c, "0017") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "001a") == 0) { *model = PI_MODEL_CM ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else if (strcmp (c, "0012") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "0015") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EMBEST  ; }
-    else if (strcmp (c, "0018") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_SONY    ; }
-    else if (strcmp (c, "001b") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN  ; }
+    else if (strcmp (c, "0012") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "0015") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 1 ; *maker = PI_MAKER_EMBEST ; }
+    else if (strcmp (c, "0018") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_SONY   ; }
+    else if (strcmp (c, "001b") == 0) { *model = PI_MODEL_AP ; *rev = PI_VERSION_1_1 ; *mem = 0 ; *maker = PI_MAKER_EGOMAN ; }
 
-    else                              { *model = 0           ; *rev = 0              ; *mem =   0 ; *maker = 0 ;               }
+    else                              { *model = 0           ; *rev = 0              ; *mem = 0 ; *maker = 0               ; }
   }
 
   RaspberryPiModel = *model;
@@ -3197,7 +3197,7 @@ void delayMicroseconds (unsigned int us)
   unsigned int uSecs = us % 1000000 ;
   unsigned int wSecs = us / 1000000 ;
 
-  /**/ if (us ==   0)
+  if      (us ==   0)
     return ;
   else if (us  < 100)
     delayMicrosecondsHard (us) ;
@@ -3449,7 +3449,7 @@ int wiringPiSetup (void)
   else
     wiringPiMode = WPI_MODE_PINS ;
 
-  /**/ if (piGpioLayout () == GPIO_LAYOUT_PI1_REV1)	// A, B, Rev 1, 1.1
+  if (piGpioLayout () == GPIO_LAYOUT_PI1_REV1)	// A, B, Rev 1, 1.1
   {
     pinToGpio =  pinToGpioR1 ;
     physToGpio = physToGpioR1 ;


### PR DESCRIPTION
This was driving clangd (and me) crazy - replaced with indents between the if and conditional parentheses in most places.