### PR TITLE
Switch to stdbool.h

### DIFF
--- a/devLib/lcd.c
+++ b/devLib/lcd.c
@@ -27,15 +27,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #include <wiringPi.h>
 
 #include "lcd.h"
-
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 // HD44780U Commands
 
@@ -483,9 +479,9 @@ int lcdInit (const int rows, const int cols, const int bits,
 
 // Rest of the initialisation sequence
 
-  lcdDisplay     (lcdFd, TRUE) ;
-  lcdCursor      (lcdFd, FALSE) ;
-  lcdCursorBlink (lcdFd, FALSE) ;
+  lcdDisplay     (lcdFd, true) ;
+  lcdCursor      (lcdFd, false) ;
+  lcdCursorBlink (lcdFd, false) ;
   lcdClear       (lcdFd) ;
 
   putCommand (lcd, LCD_ENTRY   | LCD_ENTRY_ID) ;

--- a/devLib/maxdetect.c
+++ b/devLib/maxdetect.c
@@ -24,17 +24,13 @@
 
 #include <sys/time.h>
 #include <stdio.h>
+#include <stdbool.h>
 //#include <stdlib.h>
 //#include <unistd.h>
 
 #include <wiringPi.h>
 
 #include "maxdetect.h"
-
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 
 /*
@@ -58,7 +54,7 @@ static int maxDetectLowHighWait (const int pin)
   {
     gettimeofday (&now, NULL) ;
     if (timercmp (&now, &timeUp, >))
-      return FALSE ;
+      return false ;
   }
 
 // Wait for it to go HIGH
@@ -72,10 +68,10 @@ static int maxDetectLowHighWait (const int pin)
   {
     gettimeofday (&now, NULL) ;
     if (timercmp (&now, &timeUp, >))
-      return FALSE ;
+      return false ;
   }
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -110,7 +106,7 @@ static unsigned int maxDetectClockByte (const int pin)
 /*
  * maxDetectRead:
  *	Read in and return the 4 data bytes from the MaxDetect sensor.
- *	Return TRUE/FALSE depending on the checksum validity
+ *	Return true/false depending on the checksum validity
  *********************************************************************************
  */
 
@@ -136,7 +132,7 @@ int maxDetectRead (const int pin, unsigned char buffer [4])
 // Now wait for sensor to pull pin low
 
   if (!maxDetectLowHighWait (pin))
-    return FALSE ;
+    return false ;
 
 // and read in 5 bytes (40 bits)
 
@@ -165,7 +161,7 @@ int maxDetectRead (const int pin, unsigned char buffer [4])
 // reading is probably bogus.
 
   if ((took.tv_sec != 0) || (took.tv_usec > 16000))
-    return FALSE ;
+    return false ;
 
   return checksum == localBuf [4] ;
 }
@@ -196,7 +192,7 @@ int readRHT03 (const int pin, int *temp, int *rh)
   {
     *rh   = lastRh ;
     *temp = lastTemp ;
-    return TRUE ;
+    return true ;
   }
 
 // Set timeout for next read
@@ -214,7 +210,7 @@ int readRHT03 (const int pin, int *temp, int *rh)
     result = maxDetectRead (pin, buffer) ;
 
   if (!result)
-    return FALSE ;
+    return false ;
 
   *rh   = (buffer [0] * 256 + buffer [1]) ;
   *temp = (buffer [2] * 256 + buffer [3]) ;
@@ -229,10 +225,10 @@ int readRHT03 (const int pin, int *temp, int *rh)
 //	(which does seem to happen - no realtime here)
 
   if ((*rh > 999) || (*temp > 800) || (*temp < -400))
-    return FALSE ;
+    return false ;
 
   lastRh   = *rh ;
   lastTemp = *temp ;
 
-  return TRUE ;
+  return true ;
 }

--- a/examples/Gertboard/vumeter.c
+++ b/examples/Gertboard/vumeter.c
@@ -18,15 +18,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <sys/time.h>
 
 #include <wiringPi.h>
 #include <gertboard.h>
-
-#ifndef	TRUE
-#define	TRUE	(1==1)
-#define	FALSE	(!TRUE)
-#endif
 
 #define	B_SIZE	1000
 #define	S_SIZE	 128

--- a/examples/PiFace/ladder.c
+++ b/examples/PiFace/ladder.c
@@ -7,16 +7,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <math.h>
 
 #include <wiringPi.h>
 #include <piFace.h>
-
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 #undef	DEBUG
 
@@ -244,7 +240,7 @@ void ledOnAction (void)
   if (digitalRead (PIFACE) == LOW)
   {
     chargeCapacitor () ;
-    ledBargraph (vCap, TRUE) ;
+    ledBargraph (vCap, true) ;
   }
 }
 
@@ -264,7 +260,7 @@ void ledOffAction (void)
   if (digitalRead (PIFACE) == LOW)
   {
     vCap = vCapLast = 0.0 ;
-    ledBargraph (vCap, FALSE) ;
+    ledBargraph (vCap, false) ;
 
 // Wait until we release the button
 
@@ -300,7 +296,7 @@ int main (void)
 
 // LED ON:
 
-    (void)ledBargraph (vCap, TRUE) ;
+    (void)ledBargraph (vCap, true) ;
     then = millis () + ledOnTime ;
     while (millis () < then)
     {
@@ -323,7 +319,7 @@ int main (void)
 
 // LED OFF:
 
-    (void)ledBargraph (vCap, FALSE) ;
+    (void)ledBargraph (vCap, false) ;
     then = millis () + ledOffTime ;
     while (millis () < then)
     {

--- a/examples/PiGlow/piGlow1.c
+++ b/examples/PiGlow/piGlow1.c
@@ -25,17 +25,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <poll.h>
 
 #include <wiringPi.h>
 #include <piGlow.h>
 
 #define	PIGLOW_BASE	533
-
-#ifndef	TRUE
-#  define TRUE  (1==1)
-#  define FALSE (!TRUE)
-#endif
 
 
 /*

--- a/examples/PiGlow/piglow.c
+++ b/examples/PiGlow/piglow.c
@@ -26,11 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-
-#ifndef	TRUE
-#  define TRUE  (1==1)
-#  define FALSE (!TRUE)
-#endif
+#include <stdbool.h>
 
 #include <wiringPi.h>
 #include <piGlow.h>
@@ -81,7 +77,7 @@ int main (int argc, char *argv [])
 
 // Initialise the piGlow devLib
 
-  piGlowSetup (FALSE) ;
+  piGlowSetup (false) ;
 
   if (argc == 1)
     failUsage () ;

--- a/examples/clock.c
+++ b/examples/clock.c
@@ -35,6 +35,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <string.h>
@@ -44,11 +45,6 @@
 
 #include <wiringPi.h>
 #include <lcd128x64.h>
-
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 double clockRadius ;
 double thickness, barLen ;
@@ -130,15 +126,15 @@ void drawClockFace (void)
   double d, px1, py1, px2, py2 ;
 
   lcd128x64clear (0) ;
-  lcd128x64circle (0,0, clockRadius, 1, TRUE) ;
-  lcd128x64circle (0,0, clockRadius - thickness, 0, TRUE) ;
+  lcd128x64circle (0,0, clockRadius, 1, true) ;
+  lcd128x64circle (0,0, clockRadius - thickness, 0, true) ;
 
 // The four big indicators for 12,15,30 and 45
 
-  lcd128x64rectangle (- 3,  clockRadius - barLen, 3,  clockRadius,     1, TRUE) ;	// 12
-  lcd128x64rectangle (clockRadius - barLen, 3,  clockRadius, -3, 1, TRUE) ;	// 3
-  lcd128x64rectangle (- 3, -clockRadius + barLen, 3, -clockRadius, 1, TRUE) ;	// 6
-  lcd128x64rectangle (-clockRadius + barLen, 3, -clockRadius, -3, 1, TRUE) ;	// 9
+  lcd128x64rectangle (- 3,  clockRadius - barLen, 3,  clockRadius,     1, true) ;	// 12
+  lcd128x64rectangle (clockRadius - barLen, 3,  clockRadius, -3, 1, true) ;	// 3
+  lcd128x64rectangle (- 3, -clockRadius + barLen, 3, -clockRadius, 1, true) ;	// 6
+  lcd128x64rectangle (-clockRadius + barLen, 3, -clockRadius, -3, 1, true) ;	// 9
 
 
 // Smaller 5 and 1 minute ticks

--- a/examples/lcd-adafruit.c
+++ b/examples/lcd-adafruit.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
@@ -33,11 +34,6 @@
 #include <wiringPi.h>
 #include <mcp23017.h>
 #include <lcd.h>
-
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 
 // Defines for the Adafruit Pi LCD interface board
@@ -251,7 +247,7 @@ int main (int argc, char *argv[])
 {
   int colour ;
   int cols = 16 ;
-  int waitForRelease = FALSE ;
+  int waitForRelease = false ;
 
   struct tm *t ;
   time_t tim ;
@@ -287,13 +283,13 @@ int main (int argc, char *argv[])
   lcdPuts     (lcdHandle, "User Char: ") ;
   lcdPutchar  (lcdHandle, 2) ;
 
-  lcdCursor      (lcdHandle, TRUE) ;
-  lcdCursorBlink (lcdHandle, TRUE) ;
+  lcdCursor      (lcdHandle, true) ;
+  lcdCursorBlink (lcdHandle, true) ;
 
   waitForEnter () ;
 
-  lcdCursor      (lcdHandle, FALSE) ;
-  lcdCursorBlink (lcdHandle, FALSE) ;
+  lcdCursor      (lcdHandle, false) ;
+  lcdCursorBlink (lcdHandle, false) ;
 
   speedTest () ;
 
@@ -320,7 +316,7 @@ int main (int argc, char *argv[])
       if ((digitalRead (AF_UP) == LOW) || (digitalRead (AF_DOWN) == LOW))
 	continue ;
       else
-	waitForRelease = FALSE ;
+	waitForRelease = false ;
     }
 
     if (digitalRead (AF_UP) == LOW)	// Pushed
@@ -329,7 +325,7 @@ int main (int argc, char *argv[])
       if (colour == 8)
 	colour = 0 ;
       setBacklightColour (colour) ;
-      waitForRelease = TRUE ;
+      waitForRelease = true ;
     }
 
     if (digitalRead (AF_DOWN) == LOW)	// Pushed
@@ -338,7 +334,7 @@ int main (int argc, char *argv[])
       if (colour == -1)
 	colour = 7 ;
       setBacklightColour (colour) ;
-      waitForRelease = TRUE ;
+      waitForRelease = true ;
     }
 
   }

--- a/examples/lcd.c
+++ b/examples/lcd.c
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <unistd.h>
@@ -47,10 +48,6 @@
 #include <wiringPi.h>
 #include <lcd.h>
 
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 static unsigned char newChar [8] = 
 {
@@ -247,13 +244,13 @@ int main (int argc, char *argv[])
   lcdPuts     (lcdHandle, "User Char: ") ;
   lcdPutchar  (lcdHandle, 2) ;
 
-  lcdCursor      (lcdHandle, TRUE) ;
-  lcdCursorBlink (lcdHandle, TRUE) ;
+  lcdCursor      (lcdHandle, true) ;
+  lcdCursorBlink (lcdHandle, true) ;
 
   waitForEnter () ;
 
-  lcdCursor      (lcdHandle, FALSE) ;
-  lcdCursorBlink (lcdHandle, FALSE) ;
+  lcdCursor      (lcdHandle, false) ;
+  lcdCursorBlink (lcdHandle, false) ;
   lcdClear       (lcdHandle) ;
 
   for (;;)

--- a/examples/spiSpeed.c
+++ b/examples/spiSpeed.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <string.h>
@@ -35,9 +36,6 @@
 
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
-
-#define	TRUE	(1==1)
-#define	FALSE	(!TRUE)
 
 #define	SPI_CHAN		0
 #define	NUM_TIMES		100
@@ -78,7 +76,7 @@ int main (void)
     printf ("|   MHz |   Size | mS/Trans |      TpS |    Mb/Sec | Latency mS |\n") ;
     printf ("+-------+--------+----------+----------+-----------+------------+\n") ;
 
-    spiFail = FALSE ;
+    spiFail = false ;
     spiSetup (speed * 1000000) ;
     for (size = 1 ; size <= MAX_SIZE ; size *= 2)
     {
@@ -89,7 +87,7 @@ int main (void)
 	if (wiringPiSPIDataRW (SPI_CHAN, myData, size) == -1)
 	{
 	  printf ("SPI failure: %s\n", strerror (errno)) ;
-	  spiFail = TRUE ;
+	  spiFail = true ;
 	  break ;
 	}
       end = millis () ;

--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <ctype.h>
 #include <string.h>
@@ -50,11 +51,6 @@ int gpioDebug ;
 extern void doReadall    (void) ;
 extern void doAllReadall (void) ;
 extern void doQmode      (int argc, char *argv []) ;
-
-#ifndef TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(1==2)
-#endif
 
 #define	PI_USB_POWER_CONTROL	38
 #define	I2CDETECT		"i2cdetect"
@@ -992,12 +988,12 @@ int main (int argc, char *argv [])
   if (getenv ("WIRINGPI_DEBUG") != NULL)
   {
     printf ("gpio: wiringPi debug mode enabled\n") ;
-    wiringPiDebug = TRUE ;
+    wiringPiDebug = true ;
   }
   if (getenv ("GPIO_DEBUG") != NULL)
   {
     printf ("gpio: gpio debug mode enabled\n") ;
-    gpioDebug = TRUE ;
+    gpioDebug = true ;
   }
 
   if (argc == 1)
@@ -1159,7 +1155,7 @@ int main (int argc, char *argv [])
       exit (EXIT_FAILURE) ;
     }
 
-    if (!loadWPiExtension (argv [0], argv [2], TRUE))
+    if (!loadWPiExtension (argv [0], argv [2], true))
     {
       fprintf (stderr, "%s: Extension load failed: %s\n", argv [0], strerror (errno)) ;
       exit (EXIT_FAILURE) ;
@@ -1209,8 +1205,8 @@ int main (int argc, char *argv [])
   else if (strcasecmp (argv [1], "i2cd"     ) == 0) doI2Cdetect  (argv [0]) ;
   else if (strcasecmp (argv [1], "reset"    ) == 0) doReset      (argv [0]) ;
   else if (strcasecmp (argv [1], "wb"       ) == 0) doWriteByte  (argc, argv) ;
-  else if (strcasecmp (argv [1], "rbx"      ) == 0) doReadByte   (argc, argv, TRUE) ;
-  else if (strcasecmp (argv [1], "rbd"      ) == 0) doReadByte   (argc, argv, FALSE) ;
+  else if (strcasecmp (argv [1], "rbx"      ) == 0) doReadByte   (argc, argv, true) ;
+  else if (strcasecmp (argv [1], "rbd"      ) == 0) doReadByte   (argc, argv, false) ;
   else if (strcasecmp (argv [1], "clock"    ) == 0) doClock      (argc, argv) ;
   else if (strcasecmp (argv [1], "wfis"     ) == 0) doWfi2       (argc, argv) ;
   else if (strcasecmp (argv [1], "wfi"      ) == 0) doWfi        (argc, argv) ;

--- a/gpio/readall.c
+++ b/gpio/readall.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <ctype.h>
 #include <string.h>
@@ -36,11 +37,6 @@
 #include <wiringPi.h>
 
 extern int wpMode ;
-
-#ifndef TRUE
-#  define       TRUE    (1==1)
-#  define       FALSE   (1==2)
-#endif
 
 /*
  * doReadallExternal:

--- a/wiringPi/ads1115.c
+++ b/wiringPi/ads1115.c
@@ -35,6 +35,7 @@
 #include <byteswap.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
@@ -278,7 +279,7 @@ int ads1115Setup (const int pinBase, int i2cAddr)
   int fd ;
 
   if ((fd = wiringPiI2CSetup (i2cAddr)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 8) ;
 
@@ -289,5 +290,5 @@ int ads1115Setup (const int pinBase, int i2cAddr)
   node->analogWrite  = myAnalogWrite ;
   node->digitalWrite = myDigitalWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/bmp180.c
+++ b/wiringPi/bmp180.c
@@ -30,6 +30,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <math.h>
 
@@ -192,7 +193,7 @@ int bmp180Setup (const int pinBase)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 4) ;
 
@@ -233,5 +234,5 @@ int bmp180Setup (const int pinBase)
   p1 = 1.0 - 7357.0 * pow (2.0, -20.0) ;
   p2 = 3038.0 * 100.0 * pow (2.0,  -36.0) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/drcNet.c
+++ b/wiringPi/drcNet.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -342,12 +343,12 @@ int drcSetupNet (const int pinBase, const int numPins, const char *ipAddress, co
   struct wiringPiNodeStruct *node ;
 
   if ((fd = _drcSetupNet (ipAddress, port, password)) < 0)
-    return FALSE ;
+    return false ;
 
   len = sizeof (struct drcNetComStruct) ;
 
   if (setsockopt (fd, SOL_SOCKET, SO_RCVLOWAT, (void *)&len, sizeof (len)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, numPins) ;
 
@@ -361,5 +362,5 @@ int drcSetupNet (const int pinBase, const int numPins, const char *ipAddress, co
   node->digitalWrite     = myDigitalWrite ;
   node->pwmWrite         = myPwmWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/drcSerial.c
+++ b/wiringPi/drcSerial.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <time.h>
 #include <string.h>
 #include <errno.h>
@@ -151,7 +152,7 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
   struct wiringPiNodeStruct *node ;
 
   if ((fd = serialOpen (device, baud)) < 0)
-    return FALSE ;
+    return false ;
 
   delay (10) ;	// May need longer if it's an Uno that reboots on the open...
 
@@ -160,7 +161,7 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
   while (serialDataAvail (fd))
     (void)serialGetchar (fd) ;
 
-  ok = FALSE ;
+  ok = false ;
   for (tries = 1 ; (tries < 5) && (!ok) ; ++tries)
   {
     serialPutchar (fd, '@') ;		// Ping
@@ -170,7 +171,7 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
       {
         if (serialGetchar (fd) == '@')
         {
-          ok = TRUE ;
+          ok = true ;
           break ;
         }
       }
@@ -179,7 +180,7 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
   if (!ok)
   {
     serialClose (fd) ;
-    return FALSE ;
+    return false ;
   }
 
   node = wiringPiNewNode (pinBase, numPins) ;
@@ -192,5 +193,5 @@ int drcSetupSerial (const int pinBase, const int numPins, const char *device, co
   node->digitalWrite    = myDigitalWrite ;
   node->pwmWrite        = myPwmWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/ds18b20.c
+++ b/wiringPi/ds18b20.c
@@ -29,6 +29,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
@@ -123,7 +124,7 @@ int ds18b20Setup (const int pinBase, const char *deviceId)
 // Allocate space for the filename
 
   if ((fileName = malloc (strlen (W1_PREFIX) + strlen (W1_POSTFIX) + strlen (deviceId) + 1)) == NULL)
-    return FALSE ;
+    return false ;
 
   sprintf (fileName, "%s%s%s", W1_PREFIX, deviceId, W1_POSTFIX) ;
 
@@ -132,7 +133,7 @@ int ds18b20Setup (const int pinBase, const char *deviceId)
   free (fileName) ;
 
   if (fd < 0)
-    return FALSE ;
+    return false ;
 
 // We'll keep the file open, to make access a little faster
 //	although it's very slow reading these things anyway )-:
@@ -142,5 +143,5 @@ int ds18b20Setup (const int pinBase, const char *deviceId)
   node->fd         = fd ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/htu21d.c
+++ b/wiringPi/htu21d.c
@@ -25,6 +25,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <math.h>
 
@@ -40,7 +41,7 @@
 
 int checksum (UNU uint8_t data [4])
 {
-  return TRUE ;
+  return true ;
 }
 
 
@@ -127,7 +128,7 @@ int htu21dSetup (const int pinBase)
   int status ;
 
   if ((fd = wiringPiI2CSetup (I2C_ADDRESS)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 2) ;
 
@@ -138,7 +139,7 @@ int htu21dSetup (const int pinBase)
 
   data = 0xFE ;
   if (write (fd, &data, 1) != 1)
-    return FALSE ;
+    return false ;
 
   delay (15) ;
 
@@ -146,5 +147,5 @@ int htu21dSetup (const int pinBase)
 
   status = wiringPiI2CReadReg8 (fd, 0xE7) ;
 
-  return (status == 0x02) ? TRUE : FALSE ;
+  return (status == 0x02) ? true : false ;
 }

--- a/wiringPi/max31855.c
+++ b/wiringPi/max31855.c
@@ -24,6 +24,7 @@
 
 #include <byteswap.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
@@ -88,12 +89,12 @@ int max31855Setup (const int pinBase, int spiChannel)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiChannel, 5000000) < 0)	// 5MHz - prob 4 on the Pi
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 4) ;
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/max5322.c
+++ b/wiringPi/max5322.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stdbool.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -66,7 +68,7 @@ int max5322Setup (const int pinBase, int spiChannel)
   unsigned char spiData [2] ;
 
   if (wiringPiSPISetup (spiChannel, 8000000) < 0)	// 10MHz Max
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 2) ;
 
@@ -80,5 +82,5 @@ int max5322Setup (const int pinBase, int spiChannel)
   
   wiringPiSPIDataRW (node->fd, spiData, 2) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp23008.c
+++ b/wiringPi/mcp23008.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <pthread.h>
 
 #include "wiringPi.h"
@@ -132,7 +133,7 @@ int mcp23008Setup (const int pinBase, const int i2cAddress)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   wiringPiI2CWriteReg8 (fd, MCP23x08_IOCON, IOCON_INIT) ;
 
@@ -145,5 +146,5 @@ int mcp23008Setup (const int pinBase, const int i2cAddress)
   node->digitalWrite    = myDigitalWrite ;
   node->data2           = wiringPiI2CReadReg8 (fd, MCP23x08_OLAT) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp23016.c
+++ b/wiringPi/mcp23016.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <pthread.h>
 
 #include "wiringPi.h"
@@ -146,7 +147,7 @@ int mcp23016Setup (const int pinBase, const int i2cAddress)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   wiringPiI2CWriteReg8 (fd, MCP23016_IOCON0, IOCON_INIT) ;
   wiringPiI2CWriteReg8 (fd, MCP23016_IOCON1, IOCON_INIT) ;
@@ -160,5 +161,5 @@ int mcp23016Setup (const int pinBase, const int i2cAddress)
   node->data2           = wiringPiI2CReadReg8 (fd, MCP23016_OLAT0) ;
   node->data3           = wiringPiI2CReadReg8 (fd, MCP23016_OLAT1) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp23017.c
+++ b/wiringPi/mcp23017.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <pthread.h>
 
 #include "wiringPi.h"
@@ -177,7 +178,7 @@ int mcp23017Setup (const int pinBase, const int i2cAddress)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   wiringPiI2CWriteReg8 (fd, MCP23x17_IOCON, IOCON_INIT) ;
 
@@ -191,5 +192,5 @@ int mcp23017Setup (const int pinBase, const int i2cAddress)
   node->data2           = wiringPiI2CReadReg8 (fd, MCP23x17_OLATA) ;
   node->data3           = wiringPiI2CReadReg8 (fd, MCP23x17_OLATB) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp23s08.c
+++ b/wiringPi/mcp23s08.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "wiringPi.h"
 #include "wiringPiSPI.h"
@@ -170,7 +171,7 @@ int mcp23s08Setup (const int pinBase, const int spiPort, const int devId)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
-    return FALSE ;
+    return false ;
 
   writeByte (spiPort, devId, MCP23x08_IOCON, IOCON_INIT) ;
 
@@ -184,5 +185,5 @@ int mcp23s08Setup (const int pinBase, const int spiPort, const int devId)
   node->digitalWrite    = myDigitalWrite ;
   node->data2           = readByte (spiPort, devId, MCP23x08_OLAT) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp23s17.c
+++ b/wiringPi/mcp23s17.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "wiringPi.h"
 #include "wiringPiSPI.h"
@@ -215,7 +216,7 @@ int mcp23s17Setup (const int pinBase, const int spiPort, const int devId)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiPort, MCP_SPEED) < 0)
-    return FALSE ;
+    return false ;
 
   writeByte (spiPort, devId, MCP23x17_IOCON,  IOCON_INIT | IOCON_HAEN) ;
   writeByte (spiPort, devId, MCP23x17_IOCONB, IOCON_INIT | IOCON_HAEN) ;
@@ -231,5 +232,5 @@ int mcp23s17Setup (const int pinBase, const int spiPort, const int devId)
   node->data2           = readByte (spiPort, devId, MCP23x17_OLATA) ;
   node->data3           = readByte (spiPort, devId, MCP23x17_OLATB) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp3002.c
+++ b/wiringPi/mcp3002.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stdbool.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -65,12 +67,12 @@ int mcp3002Setup (const int pinBase, int spiChannel)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiChannel, 1000000) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 2) ;
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp3004.c
+++ b/wiringPi/mcp3004.c
@@ -24,6 +24,8 @@
  ***********************************************************************
  */
 
+#include <stdbool.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -65,12 +67,12 @@ int mcp3004Setup (const int pinBase, int spiChannel)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiChannel, 1000000) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 8) ;
 
   node->fd         = spiChannel ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp3422.c
+++ b/wiringPi/mcp3422.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
@@ -117,7 +118,7 @@ int mcp3422Setup (int pinBase, int i2cAddress, int sampleRate, int gain)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 4) ;
 
@@ -126,5 +127,5 @@ int mcp3422Setup (int pinBase, int i2cAddress, int sampleRate, int gain)
   node->data1      = gain ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/mcp4802.c
+++ b/wiringPi/mcp4802.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stdbool.h>
+
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 
@@ -65,12 +67,12 @@ int mcp4802Setup (const int pinBase, int spiChannel)
   struct wiringPiNodeStruct *node ;
 
   if (wiringPiSPISetup (spiChannel, 1000000) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 2) ;
 
   node->fd          = spiChannel ;
   node->analogWrite = myAnalogWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/pcf8574.c
+++ b/wiringPi/pcf8574.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <pthread.h>
 
 #include "wiringPi.h"
@@ -113,7 +114,7 @@ int pcf8574Setup (const int pinBase, const int i2cAddress)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 8) ;
 
@@ -123,5 +124,5 @@ int pcf8574Setup (const int pinBase, const int i2cAddress)
   node->digitalWrite = myDigitalWrite ;
   node->data2        = wiringPiI2CRead (fd) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/pcf8591.c
+++ b/wiringPi/pcf8591.c
@@ -24,6 +24,7 @@
  */
 
 #include <unistd.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "wiringPi.h"
@@ -82,7 +83,7 @@ int pcf8591Setup (const int pinBase, const int i2cAddress)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (i2cAddress)) < 0)
-    return FALSE ;
+    return false ;
 
   node = wiringPiNewNode (pinBase, 4) ;
 
@@ -90,5 +91,5 @@ int pcf8591Setup (const int pinBase, const int i2cAddress)
   node->analogRead  = myAnalogRead ;
   node->analogWrite = myAnalogWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/pseudoPins.c
+++ b/wiringPi/pseudoPins.c
@@ -41,6 +41,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
@@ -80,24 +81,24 @@ int pseudoPinsSetup(const int pinBase)
     node = wiringPiNewNode(pinBase, PSEUDO_PINS);
     if (node == NULL) {
       fprintf(stderr, "Error creating new wiringPi node");
-      return FALSE;
+      return false;
     }
 
     node->fd = shm_open(SHARED_NAME, O_CREAT | O_RDWR, 0666);
     if (node->fd < 0) {
       perror("Error opening shared memory");
-      return FALSE;
+      return false;
     }
 
     if (ftruncate(node->fd, PSEUDO_PINS * sizeof(int)) < 0) {
       perror("Error resizing shared memory");
-      return FALSE;
+      return false;
     }
 
     ptr = mmap(NULL, PSEUDO_PINS * sizeof(int), PROT_READ | PROT_WRITE, MAP_SHARED, node->fd, 0);
     if (ptr == MAP_FAILED) {
       perror("Error mapping shared memory");
-      return FALSE;
+      return false;
     }
 
     node->data0 = (unsigned int)(uintptr_t)ptr;
@@ -105,5 +106,5 @@ int pseudoPinsSetup(const int pinBase)
     node->analogRead = myAnalogRead;
     node->analogWrite = myAnalogWrite;
 
-    return TRUE;
+    return true;
 }

--- a/wiringPi/rht03.c
+++ b/wiringPi/rht03.c
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #include <stdio.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <time.h>
 
 #include "wiringPi.h"
@@ -51,7 +52,7 @@ static int maxDetectLowHighWait (const int pin)
   {
     gettimeofday (&now, NULL) ;
     if (timercmp (&now, &timeUp, >))
-      return FALSE ;
+      return false ;
   }
 
 // Wait for it to go HIGH
@@ -65,10 +66,10 @@ static int maxDetectLowHighWait (const int pin)
   {
     gettimeofday (&now, NULL) ;
     if (timercmp (&now, &timeUp, >))
-      return FALSE ;
+      return false ;
   }
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -103,7 +104,7 @@ static unsigned int maxDetectClockByte (const int pin)
 /*
  * maxDetectRead:
  *	Read in and return the 4 data bytes from the MaxDetect sensor.
- *	Return TRUE/FALSE depending on the checksum validity
+ *	Return true/false depending on the checksum validity
  *********************************************************************************
  */
 
@@ -129,7 +130,7 @@ static int maxDetectRead (const int pin, unsigned char buffer [4])
 // Now wait for sensor to pull pin low
 
   if (!maxDetectLowHighWait (pin))
-    return FALSE ;
+    return false ;
 
 // and read in 5 bytes (40 bits)
 
@@ -158,7 +159,7 @@ static int maxDetectRead (const int pin, unsigned char buffer [4])
 // reading is probably bogus.
 
   if ((took.tv_sec != 0) || (took.tv_usec > 16000))
-    return FALSE ;
+    return false ;
 
   return checksum == localBuf [4] ;
 }
@@ -181,7 +182,7 @@ static int myReadRHT03 (const int pin, int *temp, int *rh)
   result = maxDetectRead (pin, buffer) ;
 
   if (!result)
-    return FALSE ;
+    return false ;
 
   *rh   = (buffer [0] * 256 + buffer [1]) ;
   *temp = (buffer [2] * 256 + buffer [3]) ;
@@ -196,9 +197,9 @@ static int myReadRHT03 (const int pin, int *temp, int *rh)
 //	(which does seem to happen - no realtime here)
 
   if ((*rh > 999) || (*temp > 800) || (*temp < -400))
-    return FALSE ;
+    return false ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -239,7 +240,7 @@ int rht03Setup (const int pinBase, const int piPin)
   struct wiringPiNodeStruct *node ;
 
   if ((piPin & PI_GPIO_MASK) != 0)	// Must be an on-board pin
-    return FALSE ;
+    return false ;
   
 // 2 pins - temperature and humidity
 
@@ -248,5 +249,5 @@ int rht03Setup (const int pinBase, const int piPin)
   node->fd         = piPin ;
   node->analogRead = myAnalogRead ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/sn3218.c
+++ b/wiringPi/sn3218.c
@@ -22,6 +22,8 @@
  ***********************************************************************
  */
 
+#include <stdbool.h>
+
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
 
@@ -55,7 +57,7 @@ int sn3218Setup (const int pinBase)
   struct wiringPiNodeStruct *node ;
 
   if ((fd = wiringPiI2CSetup (0x54)) < 0)
-    return FALSE ;
+    return false ;
 
 // Setup the chip - initialise all 18 LEDs to off
 
@@ -71,5 +73,5 @@ int sn3218Setup (const int pinBase)
   node->fd          = fd ;
   node->analogWrite = myAnalogWrite ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/sr595.c
+++ b/wiringPi/sr595.c
@@ -29,6 +29,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "wiringPi.h"
 
@@ -105,5 +106,5 @@ int sr595Setup (const int pinBase, const int numPins,
   pinMode (clockPin, OUTPUT) ;
   pinMode (latchPin, OUTPUT) ;
 
-  return TRUE ;
+  return true ;
 }

--- a/wiringPi/test/wiringpi_xotest_test1_spi.c
+++ b/wiringPi/test/wiringpi_xotest_test1_spi.c
@@ -2,14 +2,13 @@
 // Compile: gcc -Wall wiringpi_xotest_test1_spi.c -o wiringpi_xotest_test1_spi -lwiringPi
 
 #include <unistd.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <signal.h>
 #include <time.h>
 #include "wpi_test.h"
 #include <wiringPiSPI.h>
 
-#define TRUE                (1==1)
-#define FALSE               (!TRUE)
 #define CHAN_CONFIG_SINGLE  8
 #define CHAN_CONFIG_DIFF    0
 

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <ctype.h>
@@ -251,8 +252,8 @@ static volatile unsigned int GPIO_RIO ;
 #define	PAGE_SIZE		(4*1024)
 #define	BLOCK_SIZE		(4*1024)
 
-static unsigned int usingGpioMem    = FALSE ;
-static          int wiringPiSetuped = FALSE ;
+static unsigned int usingGpioMem    = false ;
+static          int wiringPiSetuped = false ;
 
 // PWM
 //	Word offsets into the PWM control region
@@ -447,12 +448,12 @@ static int RaspberryPiLayout = -1;
 
 // Debugging & Return codes
 
-int wiringPiDebug       = FALSE ;
-int wiringPiReturnCodes = FALSE ;
+int wiringPiDebug       = false ;
+int wiringPiReturnCodes = false ;
 
 // Use /dev/gpiomem ?
 
-int wiringPiTryGpioMem  = FALSE ;
+int wiringPiTryGpioMem  = false ;
 
 enum WPIFlag {
   WPI_FLAG_INPUT    = 0x04,
@@ -3423,13 +3424,13 @@ int wiringPiSetup (void)
   if (wiringPiSetuped)
     return 0 ;
 
-  wiringPiSetuped = TRUE ;
+  wiringPiSetuped = true ;
 
   if (getenv (ENV_DEBUG) != NULL)
-    wiringPiDebug = TRUE ;
+    wiringPiDebug = true ;
 
   if (getenv (ENV_CODES) != NULL)
-    wiringPiReturnCodes = TRUE ;
+    wiringPiReturnCodes = true ;
 
   if (wiringPiDebug)
     printf ("wiringPi: wiringPiSetup called\n") ;
@@ -3485,7 +3486,7 @@ int wiringPiSetup (void)
     gpioToPwmPort[19] = 3;
   }
 
-  usingGpioMem = FALSE;
+  usingGpioMem = false;
   if (gpiomemGlobal==NULL || (fd = open (gpiomemGlobal, O_RDWR | O_SYNC | O_CLOEXEC)) < 0)
   {
     if (wiringPiDebug) {
@@ -3494,7 +3495,7 @@ int wiringPiSetup (void)
     if (gpiomemModule && (fd = open (gpiomemModule, O_RDWR | O_SYNC | O_CLOEXEC) ) >= 0)	// We're using gpiomem
     {
       piGpioBase   = 0 ;
-      usingGpioMem = TRUE ;
+      usingGpioMem = true ;
     }
     else
       return wiringPiFailure (WPI_ALMOST, "wiringPiSetup: Unable to open %s or %s: %s.\n"
@@ -3678,15 +3679,15 @@ int wiringPiSetupGpioDevice (enum WPIPinType pinType) {
     printf ("wiringPi: wiringPiSetupGpioDevice(%d) called\n", (int)pinType) ;
   }
   if (getenv (ENV_DEBUG) != NULL)
-    wiringPiDebug = TRUE ;
+    wiringPiDebug = true ;
 
   if (getenv (ENV_CODES) != NULL)
-    wiringPiReturnCodes = TRUE ;
+    wiringPiReturnCodes = true ;
 
   if (wiringPiGpioDeviceGetFd()<0) {
     return -1;
   }
-  wiringPiSetuped = TRUE ;
+  wiringPiSetuped = true ;
 
   if (piGpioLayout () == GPIO_LAYOUT_PI1_REV1){
     pinToGpio  = pinToGpioR1 ;
@@ -3709,7 +3710,7 @@ int wiringPiSetupGpioDevice (enum WPIPinType pinType) {
       wiringPiMode = WPI_MODE_GPIO_DEVICE_PHYS;
       break;
     default:
-      wiringPiSetuped = FALSE;
+      wiringPiSetuped = false;
       return -1;
   }
 

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -24,13 +24,14 @@
 #ifndef	__WIRING_PI_H__
 #define	__WIRING_PI_H__
 
-// C doesn't have true/false by default and I can never remember which
-//	way round they are, so ...
-//	(and yes, I know about stdbool.h but I like capitals for these and I'm old)
+#include <stdbool.h>
 
-#ifndef	TRUE
-#  define	TRUE	(1==1)
-#  define	FALSE	(!TRUE)
+// macros retained for old code compatibility, we now use stdbool.h
+#ifndef TRUE
+  #define TRUE true
+#endif
+#ifndef FALSE
+  #define FALSE false
 #endif
 
 // GCC warning suppressor

--- a/wiringPi/wpiExtensions.c
+++ b/wiringPi/wpiExtensions.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdarg.h>
 #include <ctype.h>
@@ -146,7 +147,7 @@ static char *extractInt (char *progName, char *p, int *num)
 static char *extractStr (char *progName, char *p, char **str)
 {
   char *q, *r ;
-  int quoted = FALSE ;
+  int quoted = false ;
 
   if (*p != ':')
   {
@@ -158,7 +159,7 @@ static char *extractStr (char *progName, char *p, char **str)
 
   if (*p == '[')
   {
-    quoted = TRUE ;
+    quoted = true ;
     ++p ;
   }
 
@@ -205,17 +206,17 @@ static int doExtensionMcp23008 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x01) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp23008Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -231,17 +232,17 @@ static int doExtensionMcp23016 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp23016Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -257,17 +258,17 @@ static int doExtensionMcp23017 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp23017Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -283,26 +284,26 @@ static int doExtensionMcp23s08 (char *progName, int pinBase, char *params)
   int spi, port ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI address (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &port)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((port < 0) || (port > 7))
   {
     verbError ("%s: port address (%d) out of range", progName, port) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp23s08Setup (pinBase, spi, port) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -318,26 +319,26 @@ static int doExtensionMcp23s17 (char *progName, int pinBase, char *params)
   int spi, port ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI address (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &port)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((port < 0) || (port > 7))
   {
     verbError ("%s: port address (%d) out of range", progName, port) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp23s17Setup (pinBase, spi, port) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -355,26 +356,26 @@ static int doExtensionSr595 (char *progName, int pinBase, char *params)
 // Extract pins
 
   if ((params = extractInt (progName, params, &pins)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((pins < 8) || (pins > 32))
   {
     verbError ("%s: pin count (%d) out of range - 8-32 expected.", progName, pins) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &data)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((params = extractInt (progName, params, &clock)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((params = extractInt (progName, params, &latch)) == NULL)
-    return FALSE ;
+    return false ;
 
   sr595Setup (pinBase, pins, data, clock, latch) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -390,17 +391,17 @@ static int doExtensionPcf8574 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   pcf8574Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -416,17 +417,17 @@ static int doExtensionAds1115 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   ads1115Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -442,17 +443,17 @@ static int doExtensionPcf8591 (char *progName, int pinBase, char *params)
   int i2c ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   pcf8591Setup (pinBase, i2c) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -467,7 +468,7 @@ static int doExtensionPseudoPins (UNU char *progName, int pinBase, UNU char *par
 {
   pseudoPinsSetup (pinBase) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -482,7 +483,7 @@ static int doExtensionBmp180 (UNU char *progName, int pinBase, UNU char *params)
 {
   bmp180Setup (pinBase) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -497,7 +498,7 @@ static int doExtensionHtu21d (UNU char *progName, int pinBase, UNU char *params)
 {
   htu21dSetup (pinBase) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -513,7 +514,7 @@ static int doExtensionDs18b20 (char *progName, int pinBase, char *params)
   char *serialNum ;
 
   if ((params = extractStr (progName, params, &serialNum)) == NULL)
-    return FALSE ;
+    return false ;
 
   return ds18b20Setup (pinBase, serialNum) ;
 }
@@ -531,7 +532,7 @@ static int doExtensionRht03 (char *progName, int pinBase, char *params)
   int piPin ;
 
   if ((params = extractInt (progName, params, &piPin)) == NULL)
-    return FALSE ;
+    return false ;
 
   return rht03Setup (pinBase, piPin) ;
 }
@@ -549,17 +550,17 @@ static int doExtensionMax31855 (char *progName, int pinBase, char *params)
   int spi ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI channel (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   max31855Setup (pinBase, spi) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -575,17 +576,17 @@ static int doExtensionMcp3002 (char *progName, int pinBase, char *params)
   int spi ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI channel (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp3002Setup (pinBase, spi) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -601,17 +602,17 @@ static int doExtensionMcp3004 (char *progName, int pinBase, char *params)
   int spi ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI channel (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp3004Setup (pinBase, spi) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -627,17 +628,17 @@ static int doExtensionMax5322 (char *progName, int pinBase, char *params)
   int spi ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI channel (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   max5322Setup (pinBase, spi) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -653,17 +654,17 @@ static int doExtensionMcp4802 (char *progName, int pinBase, char *params)
   int spi ;
 
   if ((params = extractInt (progName, params, &spi)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((spi < 0) || (spi > 1))
   {
     verbError ("%s: SPI channel (%d) out of range", progName, spi) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp4802Setup (pinBase, spi) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -677,7 +678,7 @@ static int doExtensionMcp4802 (char *progName, int pinBase, char *params)
 static int doExtensionSn3218 (UNU char *progName, int pinBase, UNU char *params)
 {
   sn3218Setup (pinBase) ;
-  return TRUE ;
+  return true ;
 }
 
 
@@ -693,35 +694,35 @@ static int doExtensionMcp3422 (char *progName, int pinBase, char *params)
   int i2c, sampleRate, gain ;
 
   if ((params = extractInt (progName, params, &i2c)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((i2c < 0x03) || (i2c > 0x77))
   {
     verbError ("%s: i2c address (0x%X) out of range", progName, i2c) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &sampleRate)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((sampleRate < 0) || (sampleRate > 3))
   {
     verbError ("%s: sample rate (%d) out of range", progName, sampleRate) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &gain)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((gain < 0) || (gain > 3))
   {
     verbError ("%s: gain (%d) out of range", progName, gain) ;
-    return FALSE ;
+    return false ;
   }
 
   mcp3422Setup (pinBase, i2c, sampleRate, gain) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -738,35 +739,35 @@ static int doExtensionDrcS (char *progName, int pinBase, char *params)
   int pins, baud ;
 
   if ((params = extractInt (progName, params, &pins)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((pins < 1) || (pins > 1000))
   {
     verbError ("%s: pins (%d) out of range (2-1000)", progName, pins) ;
-    return FALSE ;
+    return false ;
   }
   
   if ((params = extractStr (progName, params, &port)) == NULL)
-    return FALSE ;
+    return false ;
 
   if (strlen (port) == 0)
   {
     verbError ("%s: serial port device name required", progName) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractInt (progName, params, &baud)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((baud < 1) || (baud > 4000000))
   {
     verbError ("%s: baud rate (%d) out of range", progName, baud) ;
-    return FALSE ;
+    return false ;
   }
 
   drcSetupSerial (pinBase, pins, port, baud) ;
 
-  return TRUE ;
+  return true ;
 }
 
 
@@ -784,25 +785,25 @@ static int doExtensionDrcNet (char *progName, int pinBase, char *params)
   char pPort [1024] ;
 
   if ((params = extractInt (progName, params, &pins)) == NULL)
-    return FALSE ;
+    return false ;
 
   if ((pins < 1) || (pins > 1000))
   {
     verbError ("%s: pins (%d) out of range (2-1000)", progName, pins) ;
-    return FALSE ;
+    return false ;
   }
   
   if ((params = extractStr (progName, params, &ipAddress)) == NULL)
-    return FALSE ;
+    return false ;
 
   if (strlen (ipAddress) == 0)
   {
     verbError ("%s: ipAddress required", progName) ;
-    return FALSE ;
+    return false ;
   }
 
   if ((params = extractStr (progName, params, &port)) == NULL)
-    return FALSE ;
+    return false ;
 
   if (strlen (port) == 0)
   {
@@ -811,12 +812,12 @@ static int doExtensionDrcNet (char *progName, int pinBase, char *params)
   }
 
   if ((params = extractStr (progName, params, &password)) == NULL)
-    return FALSE ;
+    return false ;
 
   if (strlen (password) == 0)
   {
     verbError ("%s: password required", progName) ;
-    return FALSE ;
+    return false ;
   }
 
   return drcSetupNet (pinBase, pins, ipAddress, port, password) ;
@@ -883,7 +884,7 @@ int loadWPiExtension (char *progName, char *extensionData, int printErrors)
     if (!*p)	// ran out of characters
     {
       verbError ("%s: extension name not terminated by a colon", progName) ;
-      return FALSE ;
+      return false ;
     }
     ++p ;
   }
@@ -894,7 +895,7 @@ int loadWPiExtension (char *progName, char *extensionData, int printErrors)
   if (!isdigit (*p))
   {
     verbError ("%s: decimal pinBase number expected after extension name", progName) ;
-    return FALSE ;
+    return false ;
   }
 
   while (isdigit (*p))
@@ -902,7 +903,7 @@ int loadWPiExtension (char *progName, char *extensionData, int printErrors)
     if (pinBase > 2147483647) // 2^31-1 ... Lets be realistic here...
     {
       verbError ("%s: pinBase too large", progName) ;
-      return FALSE ;
+      return false ;
     }
 
     pinBase = pinBase * 10 + (*p - '0') ;
@@ -912,7 +913,7 @@ int loadWPiExtension (char *progName, char *extensionData, int printErrors)
   if (pinBase < 64)
   {
     verbError ("%s: pinBase (%d) too small. Minimum is 64.", progName, pinBase) ;
-    return FALSE ;
+    return false ;
   }
 
 // Search for extensions:
@@ -924,5 +925,5 @@ int loadWPiExtension (char *progName, char *extensionData, int printErrors)
   }
 
   fprintf (stderr, "%s: extension %s not found", progName, extension) ;
-  return FALSE ;
+  return false ;
 }

--- a/wiringPiD/network.c
+++ b/wiringPiD/network.c
@@ -26,6 +26,7 @@
 #include <arpa/inet.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <stdarg.h>
@@ -35,9 +36,6 @@
 #include <crypt.h>
 
 #include "network.h"
-
-#define	TRUE	(1==1)
-#define	FALSE	(!TRUE)
 
 // Local data
 

--- a/wiringPiD/runRemote.c
+++ b/wiringPiD/runRemote.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
@@ -40,7 +41,7 @@
 
 
 
-int noLocalPins = FALSE ;
+int noLocalPins = false ;
 
 
 void runRemoteCommands (int fd)

--- a/wiringPiD/wiringpid.c
+++ b/wiringPiD/wiringpid.c
@@ -22,6 +22,7 @@
 
 #include <arpa/inet.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -46,7 +47,7 @@
 // Globals
 
 static const char *usage = "[-h] [-d] [-g | -1 | -z] [[-x extension:pin:params] ...] password" ;
-static int doDaemon = FALSE ;
+static int doDaemon = false ;
 
 //
 
@@ -156,7 +157,7 @@ int main (int argc, char *argv [])
       exit (EXIT_FAILURE) ;
     }
 
-    doDaemon = TRUE ;
+    doDaemon = true ;
     daemonise (PIDFILE) ;
 
     for (i = 2 ; i < argc ; ++i)
@@ -216,7 +217,7 @@ int main (int argc, char *argv [])
       for (i = 2 ; i < argc ; ++i)
 	argv [i - 1] = argv [i] ;
       --argc ;
-      noLocalPins = TRUE ;
+      noLocalPins = true ;
       ++wpiSetup ;
       continue ;
     }
@@ -263,7 +264,7 @@ int main (int argc, char *argv [])
 
       logMsg ("Loading extension: %s", argv [2]) ;
 
-      if (!loadWPiExtension (argv [0], argv [2], TRUE))
+      if (!loadWPiExtension (argv [0], argv [2], true))
       {
 	logMsg ("Extension load failed: %s", strerror (errno)) ;
 	exit (EXIT_FAILURE) ;


### PR DESCRIPTION
Switch to using `stdbool.h` and `true`/`false` keyword macros instead of WiringPi-specific `TRUE` and `FALSE` #defines
 - Done mainly to improve forward-compatibility. As of C23, `true` and `false` are core keywords and stdbool.h does nothing.
 - `#define TRUE true` and `#define FALSE false` are left in `wiringPi.h` for compatibility with existing outside code implementing WiringPi.