### PR TITLE
(Redo #347) [wiringPi.c] Add: delayNanoseconds(), nanos(), piNanos64() and rework all delay functions

### DIFF
--- a/documentation/english/functions.md
+++ b/documentation/english/functions.md
@@ -894,3 +894,30 @@ int fd_spi = wiringPiSPIGetFd(spiChannel);
 
 wiringPiSPIClose(spiChannel);
 ```
+
+## Utility Functions
+
+### `delay()` / `delayMicroseconds()` / `delayNanoseconds()`
+
+Resume execution only after the specified amount of time has elapsed.
+
+>>>
+```C
+// Wait for some number of milliseconds
+void delay (unsigned int howLong_ms);
+
+// Wait for some number of microseconds
+void delayMicroseconds (unsigned int howLong_us);
+
+// Wait for some number of nanoseconds
+void delayNanoseconds (unsigned int howLong_ns);
+```
+
+``howLong_ms``: Length of time (in milliseconds) to delay.  
+``howLong_us``: Length of time (in microseconds) to delay.  
+``howLong_ns``: Length of time (in nanoseconds) to delay.  
+
+**Note**:  
+Internal implementation uses `clock_nanosleep()`, which which guarantees only that execution will resume *after* the specified amount of time has elapsed *at minimum*. There is no guarantee on the maximum length of the delay; however, any overshoot is unlikely to be longer than several microseconds in most cases, which should not be an issue except for very short delays.  
+As such, for delays under 100 microseconds an alternate method is used which generally limits overshoot to several tens of nanoseconds at the cost of occupying the CPU core at 100%.
+

--- a/documentation/english/functions.md
+++ b/documentation/english/functions.md
@@ -921,3 +921,30 @@ void delayNanoseconds (unsigned int howLong_ns);
 Internal implementation uses `clock_nanosleep()`, which which guarantees only that execution will resume *after* the specified amount of time has elapsed *at minimum*. There is no guarantee on the maximum length of the delay; however, any overshoot is unlikely to be longer than several microseconds in most cases, which should not be an issue except for very short delays.  
 As such, for delays under 100 microseconds an alternate method is used which generally limits overshoot to several tens of nanoseconds at the cost of occupying the CPU core at 100%.
 
+### `millis()` / `micros()` / `nanos()`
+
+Return the length of time elapsed since `wiringPiSetup()` was called (in milliseconds, microseconds, and nanoseconds, respectively). Value wraps via overflow on the specified interval for each respective function.
+
+```C
+// Returns the elapsed time in milliseconds. Wraps after ~49 days.
+unsigned int millis (void);
+
+// Returns the elapsed time in microseconds. Wraps after ~71 minutes.
+unsigned int micros (void);
+
+// Returns the elapsed time in nanoseconds. Wraps after ~4.29 seconds.
+unsigned int nanos (void);
+```
+
+
+### `piMicros64()` / `piNanos64()`
+
+Return the length of time elapsed since `wiringPiSetup()` was called (in microseconds and nanoseconds, respectively) as a 64-bit value on supported hardware.
+
+```C
+// Returns the elapsed time in microseconds. Wraps after ~584 thousand years on 64-bit hardware.
+unsigned long long int piMicros64 (void);
+
+// Returns the elapsed time in nanoseconds. Wraps after ~584 years on 64-bit hardware.
+unsigned long long int piNanos64 (void);
+```

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -3224,8 +3224,9 @@ static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow)
 
 /*
  * initialiseEpoch:
- *	Initialise our start-of-time variable to be the current unix
- *	time in milliseconds and microseconds.
+ *  Initialise our start-of-time variables to be the current unix
+ *  time in milliseconds, microseconds, and nanoseconds respectively.
+ *  Called automatically by wiringPiSetup().
  *********************************************************************************
  */
 
@@ -3241,8 +3242,8 @@ static void initialiseEpoch (void) {
 
 /*
  * millis:
- *	Return a number of milliseconds as an unsigned int.
- *	Wraps after 49 days.
+ *  Return a number of milliseconds as an unsigned int.
+ *  Wraps (via overflow) after ~49 days.
  *********************************************************************************
  */
 
@@ -3258,8 +3259,8 @@ unsigned int millis (void) {
 
 /*
  * micros:
- *	Return a number of microseconds as an unsigned int.
- *	Wraps after 71 minutes.
+ *  Return a number of microseconds as an unsigned int.
+ *  Wraps (via overflow) after ~71 minutes.
  *********************************************************************************
  */
 
@@ -3275,8 +3276,8 @@ unsigned int micros (void) {
 
 /*
  * nanos:
- *	Return a number of nanoseconds as an unsigned int.
- *	Wraps after 4.29 seconds.
+ *  Return a number of nanoseconds as an unsigned int.
+ *  Wraps (via overflow) after ~4.29 seconds.
  *********************************************************************************
  */
 
@@ -3289,6 +3290,12 @@ unsigned int nanos (void) {
   return (uint32_t)(now - epochNano) ;
 }
 
+/*
+ * piMicros64:
+ *  Return a number of microseconds as an unsigned long long int.
+ *  Wraps (via overflow) after ~584 thousand years 64-bit hardware.
+ *********************************************************************************
+ */
 
 unsigned long long piMicros64(void) {
   struct  timespec ts;
@@ -3298,6 +3305,13 @@ unsigned long long piMicros64(void) {
 
   return (now - epochMicro) ;
 }
+
+/*
+ * piNanos64:
+ *  Return a number of nanoseconds as an unsigned long long int.
+ *  Wraps (via overflow) after ~584 years on 64-bit hardware.
+ *********************************************************************************
+ */
 
 unsigned long long piNanos64(void) {
   struct  timespec ts;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -3125,7 +3125,7 @@ static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow)
 
 /*
  * delay:
- *	Wait for some number of milliseconds
+ *  Wait for some number of milliseconds
  *********************************************************************************
  */
 
@@ -3137,21 +3137,7 @@ void delay (unsigned int howLong_ms) {
 
 /*
  * delayMicroseconds:
- *	Wait for some number of microseconds
- *********************************************************************************
- *	This is somewhat intersting. It seems that on the Pi, a single call
- *	to nanosleep takes some 80 to 130 microseconds anyway, so while
- *	obeying the standards (may take longer), it's not always what we
- *	want!
- *
- *	So what I'll do now is if the delay is less than 100uS we'll do it
- *	in a hard loop, watching a built-in counter on the ARM chip. This is
- *	somewhat sub-optimal in that it uses 100% CPU, something not an issue
- *	in a microcontroller, but under a multi-tasking, multi-user OS, it's
- *	wastefull, however we've no real choice )-:
- *
- *      Plan B: It seems all might not be well with that plan, so changing it
- *      to use gettimeofday () and poll on that instead...
+ *  Wait for some number of microseconds
  *********************************************************************************
  */
 
@@ -3166,21 +3152,7 @@ void delayMicrosecondsHard (unsigned int howLong_us);
 
 /*
  * delayNanoseconds:
- *	Wait for some number of nanoseconds
- *********************************************************************************
- *	This is somewhat intersting. It seems that on the Pi, a single call
- *	to nanosleep takes some 80 to 130 microseconds anyway, so while
- *	obeying the standards (may take longer), it's not always what we
- *	want!
- *
- *	So what I'll do now is if the delay is less than 100uS we'll do it
- *	in a hard loop, watching a built-in counter on the ARM chip. This is
- *	somewhat sub-optimal in that it uses 100% CPU, something not an issue
- *	in a microcontroller, but under a multi-tasking, multi-user OS, it's
- *	wastefull, however we've no real choice )-:
- *
- *      Plan B: It seems all might not be well with that plan, so changing it
- *      to use gettimeofday () and poll on that instead...
+ *  Wait for some number of nanoseconds
  *********************************************************************************
  */
 
@@ -3190,6 +3162,22 @@ void delayNanoseconds (unsigned int howLong_ns) {
   }
 }
 
+/*
+ * delayHelper:
+ *  Internal helper function for delays - not externally accessible.
+ *********************************************************************************
+ *  This is somewhat intersting. It seems that on the Pi, a single call
+ *  to nanosleep takes some 80 to 130 microseconds anyway, so while
+ *  obeying the standards (may take longer), it's not always what we
+ *  want!
+ *
+ *  So what I'll do now is if the delay is less than 100uS we'll do it
+ *  in a hard loop, comparing the current time against the scheduled end.
+ *  This is somewhat sub-optimal in that it uses 100% CPU, something not an
+ *  issue in a microcontroller, but under a multi-tasking, multi-user OS, it's
+ *  wasteful, however we've no real choice )-:
+ *********************************************************************************
+ */
 
 static inline void delayHelper(unsigned long howLong_s, unsigned long howLong_ns) {
   struct timespec tsNow, tsEnd;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -435,7 +435,7 @@ const int piMemorySize [8] =
 
 // Time for easy calculations
 
-static uint64_t epochMilli, epochMicro ;
+static uint64_t epochMilli, epochMicro, epochNano ;
 
 // Misc
 
@@ -3119,31 +3119,6 @@ int wiringPiISR2(int pin, int edgeMode, void (*function)(struct WPIWfiStatus wfi
   return wiringPiISRInternal(pin, edgeMode, function, NULL, debounce_period_us, userdata);
 }
 
-/*
- * initialiseEpoch:
- *	Initialise our start-of-time variable to be the current unix
- *	time in milliseconds and microseconds.
- *********************************************************************************
- */
-
-static void initialiseEpoch (void)
-{
-#ifdef	OLD_WAY
-  struct timeval tv ;
-
-  gettimeofday (&tv, NULL) ;
-  epochMilli = (uint64_t)tv.tv_sec * (uint64_t)1000    + (uint64_t)(tv.tv_usec / 1000) ;
-  epochMicro = (uint64_t)tv.tv_sec * (uint64_t)1000000 + (uint64_t)(tv.tv_usec) ;
-#else
-  struct timespec ts ;
-
-  clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
-  epochMilli = (uint64_t)ts.tv_sec * (uint64_t)1000    + (uint64_t)(ts.tv_nsec / 1000000L) ;
-  epochMicro = (uint64_t)ts.tv_sec * (uint64_t)1000000 + (uint64_t)(ts.tv_nsec /    1000L) ;
-#endif
-}
-
-
 // Helper functions
 static inline void delayHelper(unsigned long howLong_s, unsigned long howLong_ns);
 static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow);
@@ -3260,28 +3235,34 @@ static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow)
 
 
 /*
- * millis:
- *	Return a number of milliseconds as an unsigned int.
- *	Wraps at 49 days.
+ * initialiseEpoch:
+ *	Initialise our start-of-time variable to be the current unix
+ *	time in milliseconds and microseconds.
  *********************************************************************************
  */
 
-unsigned int millis (void)
-{
-  uint64_t now ;
-
-#ifdef	OLD_WAY
-  struct timeval tv ;
-
-  gettimeofday (&tv, NULL) ;
-  now  = (uint64_t)tv.tv_sec * (uint64_t)1000 + (uint64_t)(tv.tv_usec / 1000) ;
-
-#else
-  struct  timespec ts ;
+static void initialiseEpoch (void) {
+  struct timespec ts ;
 
   clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
-  now  = (uint64_t)ts.tv_sec * (uint64_t)1000 + (uint64_t)(ts.tv_nsec / 1000000L) ;
-#endif
+  epochMilli = (uint64_t)ts.tv_sec * (uint64_t)1000       + (uint64_t)(ts.tv_nsec / 1000000L) ;
+  epochMicro = (uint64_t)ts.tv_sec * (uint64_t)1000000    + (uint64_t)(ts.tv_nsec / 1000L) ;
+  epochNano  = (uint64_t)ts.tv_sec * (uint64_t)1000000000 + (uint64_t)(ts.tv_nsec) ;
+}
+
+
+/*
+ * millis:
+ *	Return a number of milliseconds as an unsigned int.
+ *	Wraps after 49 days.
+ *********************************************************************************
+ */
+
+unsigned int millis (void) {
+  struct timespec ts ;
+
+  clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
+  uint64_t now = (uint64_t)ts.tv_sec * (uint64_t)1000 + (uint64_t)(ts.tv_nsec / 1000000L) ;
 
   return (uint32_t)(now - epochMilli) ;
 }
@@ -3294,23 +3275,30 @@ unsigned int millis (void)
  *********************************************************************************
  */
 
-unsigned int micros (void)
-{
-  uint64_t now ;
-#ifdef	OLD_WAY
-  struct timeval tv ;
-
-  gettimeofday (&tv, NULL) ;
-  now  = (uint64_t)tv.tv_sec * (uint64_t)1000000 + (uint64_t)tv.tv_usec ;
-#else
-  struct  timespec ts ;
+unsigned int micros (void) {
+  struct timespec ts ;
 
   clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
-  now  = (uint64_t)ts.tv_sec * (uint64_t)1000000 + (uint64_t)(ts.tv_nsec / 1000) ;
-#endif
-
+  uint64_t now  = (uint64_t)ts.tv_sec * (uint64_t)1000000 + (uint64_t)(ts.tv_nsec / 1000L) ;
 
   return (uint32_t)(now - epochMicro) ;
+}
+
+
+/*
+ * nanos:
+ *	Return a number of nanoseconds as an unsigned int.
+ *	Wraps after 4.29 seconds.
+ *********************************************************************************
+ */
+
+unsigned int nanos (void) {
+  struct timespec ts ;
+
+  clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
+  uint64_t now  = (uint64_t)ts.tv_sec * (uint64_t)1000000000 + (uint64_t)(ts.tv_nsec) ;
+
+  return (uint32_t)(now - epochNano) ;
 }
 
 
@@ -3319,8 +3307,19 @@ unsigned long long piMicros64(void) {
 
   clock_gettime (CLOCK_MONOTONIC_RAW, &ts) ;
   uint64_t now  = (uint64_t)ts.tv_sec * (uint64_t)1000000 + (uint64_t)(ts.tv_nsec / 1000) ;
+
   return (now - epochMicro) ;
 }
+
+unsigned long long piNanos64(void) {
+  struct  timespec ts;
+
+  clock_gettime (CLOCK_MONOTONIC_RAW, &ts);
+  uint64_t now  = (uint64_t)ts.tv_sec * (uint64_t)1000000000 + (uint64_t)(ts.tv_nsec);
+
+  return (now - epochNano);
+}
+
 
 /*
  * wiringPiVersion:

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -58,6 +58,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <ctype.h>
+#include <limits.h>
 #include <poll.h>
 #include <unistd.h>
 #include <errno.h>
@@ -3143,25 +3144,26 @@ static void initialiseEpoch (void)
 }
 
 
+// Helper functions
+static inline void delayHelper(unsigned long howLong_s, unsigned long howLong_ns);
+static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow);
+
 /*
  * delay:
  *	Wait for some number of milliseconds
  *********************************************************************************
  */
 
-void delay (unsigned int ms)
-{
-  struct timespec sleeper, dummy ;
-
-  sleeper.tv_sec  = (time_t)(ms / 1000) ;
-  sleeper.tv_nsec = (long)(ms % 1000) * 1000000 ;
-
-  nanosleep (&sleeper, &dummy) ;
+void delay (unsigned int howLong_ms) {
+  if (howLong_ms != 0) {
+    delayHelper(howLong_ms / 1000u, (howLong_ms % 1000u) * 1000000u);
+  }
 }
-
 
 /*
  * delayMicroseconds:
+ *	Wait for some number of microseconds
+ *********************************************************************************
  *	This is somewhat intersting. It seems that on the Pi, a single call
  *	to nanosleep takes some 80 to 130 microseconds anyway, so while
  *	obeying the standards (may take longer), it's not always what we
@@ -3178,35 +3180,82 @@ void delay (unsigned int ms)
  *********************************************************************************
  */
 
-void delayMicrosecondsHard (unsigned int us)
-{
-  struct timeval tNow, tLong, tEnd ;
-
-  gettimeofday (&tNow, NULL) ;
-  tLong.tv_sec  = us / 1000000 ;
-  tLong.tv_usec = us % 1000000 ;
-  timeradd (&tNow, &tLong, &tEnd) ;
-
-  while (timercmp (&tNow, &tEnd, <))
-    gettimeofday (&tNow, NULL) ;
+void delayMicroseconds (unsigned int howLong_us) {
+  if (howLong_us != 0) {
+    delayHelper(howLong_us / 1000000u, (howLong_us % 1000000u) * 1000u);
+  }
 }
 
-void delayMicroseconds (unsigned int us)
-{
-  struct timespec sleeper ;
-  unsigned int uSecs = us % 1000000 ;
-  unsigned int wSecs = us / 1000000 ;
+__attribute__((__deprecated__("Use delayMicroseconds() instead."), __alias__("delayMicroseconds")))
+void delayMicrosecondsHard (unsigned int howLong_us);
 
-  if      (us ==   0)
-    return ;
-  else if (us  < 100)
-    delayMicrosecondsHard (us) ;
-  else
-  {
-    sleeper.tv_sec  = wSecs ;
-    sleeper.tv_nsec = (long)(uSecs * 1000L) ;
-    nanosleep (&sleeper, NULL) ;
+/*
+ * delayNanoseconds:
+ *	Wait for some number of nanoseconds
+ *********************************************************************************
+ *	This is somewhat intersting. It seems that on the Pi, a single call
+ *	to nanosleep takes some 80 to 130 microseconds anyway, so while
+ *	obeying the standards (may take longer), it's not always what we
+ *	want!
+ *
+ *	So what I'll do now is if the delay is less than 100uS we'll do it
+ *	in a hard loop, watching a built-in counter on the ARM chip. This is
+ *	somewhat sub-optimal in that it uses 100% CPU, something not an issue
+ *	in a microcontroller, but under a multi-tasking, multi-user OS, it's
+ *	wastefull, however we've no real choice )-:
+ *
+ *      Plan B: It seems all might not be well with that plan, so changing it
+ *      to use gettimeofday () and poll on that instead...
+ *********************************************************************************
+ */
+
+void delayNanoseconds (unsigned int howLong_ns) {
+  if (howLong_ns != 0) {
+    delayHelper(howLong_ns / 1000000000u, howLong_ns % 1000000000u);
   }
+}
+
+
+static inline void delayHelper(unsigned long howLong_s, unsigned long howLong_ns) {
+  struct timespec tsNow, tsEnd;
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &tsEnd);
+
+  tsEnd.tv_sec += howLong_s + ((tsEnd.tv_nsec + howLong_ns) / 1000000000l);
+  tsEnd.tv_nsec = (tsEnd.tv_nsec + howLong_ns) % 1000000000l;
+
+  if (howLong_s == 0 && howLong_ns < 100000l) {
+    delayHelperHard(tsEnd, tsNow);
+    return;
+  }
+
+  // Using TIMER_ABSTIME flag allows for an absolute future time to be set.
+  while (clock_nanosleep(CLOCK_MONOTONIC_RAW, TIMER_ABSTIME, &tsEnd, NULL)) {
+
+    // If interrupted, check if less than 100 microseconds remain
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tsNow);
+    if (((tsEnd.tv_sec - tsNow.tv_sec) * 1000000000l + (tsEnd.tv_nsec - tsNow.tv_nsec)) < 100000l) {
+      delayHelperHard(tsEnd, tsNow);
+      return;
+    }
+
+    // Otherwise, repeat clock_nanosleep until return code is 0.
+  }
+}
+
+/*
+ * delayHelperHard:
+ *  Internal helper function for delays - not externally accessible.
+ *  Uses a hard loop to wait until the system clock is past the
+ *  scheduled end time.
+ *  Appears to be precice to around ~25 ns (via limited testing on a Pi 5).
+ *********************************************************************************
+ */
+
+static inline void delayHelperHard(struct timespec tsEnd, struct timespec tsNow) {
+  do {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tsNow);
+  } while ((tsNow.tv_nsec < tsEnd.tv_nsec && tsNow.tv_sec <= tsEnd.tv_sec) || tsNow.tv_sec < tsEnd.tv_sec);
 }
 
 

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -320,9 +320,14 @@ extern int piHiPri (const int pri) ;
 
 // Extras from arduino land
 
-extern void         delay             (unsigned int howLong_ms); // Wait for some number of milliseconds
-extern void         delayMicroseconds (unsigned int howLong_us); // Wait for some number of microseconds
-extern void         delayNanoseconds  (unsigned int howLong_ns); // Wait for some number of nanoseconds
+// Delay functions: sleep until the specified interval has expired.
+
+// Wait for some number of milliseconds
+extern void delay (unsigned int howLong_ms);
+// Wait for some number of microseconds
+extern void delayMicroseconds (unsigned int howLong_us);
+// Wait for some number of nanoseconds
+extern void delayNanoseconds (unsigned int howLong_ns);
 
 extern unsigned int millis            (void);
 extern unsigned int micros            (void);

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -320,8 +320,9 @@ extern int piHiPri (const int pri) ;
 
 // Extras from arduino land
 
-extern void         delay             (unsigned int ms) ;
-extern void         delayMicroseconds (unsigned int us) ;
+extern void         delay             (unsigned int howLong_ms); // Wait for some number of milliseconds
+extern void         delayMicroseconds (unsigned int howLong_us); // Wait for some number of microseconds
+extern void         delayNanoseconds  (unsigned int howLong_ns); // Wait for some number of nanoseconds
 extern unsigned int millis            (void) ;
 extern unsigned int micros            (void) ;
 

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -323,10 +323,13 @@ extern int piHiPri (const int pri) ;
 extern void         delay             (unsigned int howLong_ms); // Wait for some number of milliseconds
 extern void         delayMicroseconds (unsigned int howLong_us); // Wait for some number of microseconds
 extern void         delayNanoseconds  (unsigned int howLong_ns); // Wait for some number of nanoseconds
-extern unsigned int millis            (void) ;
-extern unsigned int micros            (void) ;
+
+extern unsigned int millis            (void);
+extern unsigned int micros            (void);
+extern unsigned int nanos             (void);
 
 extern unsigned long long piMicros64(void);   // Interface V3.7
+extern unsigned long long piNanos64(void);
 
 #ifdef __cplusplus
 }

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -329,11 +329,20 @@ extern void delayMicroseconds (unsigned int howLong_us);
 // Wait for some number of nanoseconds
 extern void delayNanoseconds (unsigned int howLong_ns);
 
-extern unsigned int millis            (void);
-extern unsigned int micros            (void);
-extern unsigned int nanos             (void);
+// Clock functions: return the time since wiringPiSetup() was called.
 
-extern unsigned long long piMicros64(void);   // Interface V3.7
+// Returns the elapsed time in milliseconds. Wraps after ~49 days.
+extern unsigned int millis (void);
+// Returns the elapsed time in microseconds. Wraps after ~71 minutes.
+extern unsigned int micros (void);
+// Returns the elapsed time in nanoseconds. Wraps after ~4.29 seconds.
+extern unsigned int nanos  (void);
+
+// Interface V3.7 64-bit clock functions: return the time since wiringPiSetup() was called.
+
+// Returns the elapsed time in microseconds. Wraps after ~584 thousand years on 64-bit hardware.
+extern unsigned long long piMicros64(void);
+// Returns the elapsed time in nanoseconds. Wraps after ~584 years on 64-bit hardware.
 extern unsigned long long piNanos64(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Redo of #347 due to faulty merge. See #367.

Added new functions:

    delayNanoseconds()
    nanos() (like millis() and micros())
    piNanos64() (like piMicros64())

In addition, all of the delay functions have been reworked so that delays longer than 100 microseconds act as wrappers for clock_nanosleep(CLOCK_MONOTONIC_RAW, TIMER_ABSTIME, ...), instead of nanosleep(...).

    Using CLOCK_MONOTONIC_RAW ensures sleep duration cannot be unexpectedly changed when the system clock slews (i.e. during a leap second or if the system resynchronizes via ntp, etc.).
    Using an absolute end time ensures that if a system interrupt cuts the sleep period short, real time spent by the system between receiving the interrupt and calling clock_nanosleep again is accounted for. Note that this does not prevent clock_nanosleep itself from overshooting due to the system scheduler, and a hard loop for short sleep durations is still required.

Also removed unused #ifdef OLD_WAY conditionally compiled code from millis(), and micros(). This code only worked to microsecond precision and has been unused since v2.39.