### PR TITLE
Small fixes

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -3326,8 +3326,7 @@ int CheckPCIeFileContent(const char* pcieaddress, const char* filename, const ch
 }
 
 
-void GetRP1Memory() {
-
+void GetRP1Memory(void) {
     pciemem_RP1[0] = '\0';
     DIR *dir = opendir(pcie_path);
     struct dirent *entry;
@@ -3360,7 +3359,7 @@ int wiringPiGlobalMemoryAccess(void)
 
   piBoard();
   if (piRP1Model()) {
-    GetRP1Memory(pciemem_RP1, sizeof(pciemem_RP1));
+    GetRP1Memory();
     gpiomemGlobal = pciemem_RP1;
     MMAP_size = pciemem_RP1_Size;
     BaseAddr  = 0x00000000;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1688,7 +1688,7 @@ struct wiringPiNodeStruct *wiringPiNewNode (int pinBase, int numPins)
     if (wiringPiFindNode (pin) != NULL)
       (void)wiringPiFailure (WPI_FATAL, "wiringPiNewNode: Pin %d overlaps with existing definition\n", pin) ;
 
-  node = (struct wiringPiNodeStruct *)calloc (sizeof (struct wiringPiNodeStruct), 1) ;	// calloc zeros
+  node = (struct wiringPiNodeStruct *)calloc(1, sizeof (struct wiringPiNodeStruct));  // calloc zeros
   if (node == NULL)
     (void)wiringPiFailure (WPI_FATAL, "wiringPiNewNode: Unable to allocate memory: %s\n", strerror (errno)) ;
 


### PR DESCRIPTION
Just a couple small fixes.

- Fixed out-of-order arguments in call to `calloc(count, size)`
- Function `void GetRP1Memory()` was defined without an argument list, which is deprecated in C23. Definition re
  - Notably, a later call to the function was passed arguments. See https://github.com/WiringPi/WiringPi/commit/454d50319a59bfe31502440800d4a40ec8bc9eab#diff-7d9877dbb5ad9584a7cd544539f5e62013b7a0ae0f46600c6bbd524eacd1af3bL3363-R3362
  -  AFAICT, these should be ignored by the compiler, so I assume they were accidentally left over from a WIP edit. 
