### PR TITLE
feat: add wiringPiI2CClose function for I2C cleanup

### DIFF
--- a/wiringPi/wiringPiI2C.c
+++ b/wiringPi/wiringPiI2C.c
@@ -267,3 +267,15 @@ int wiringPiI2CSetup (const int devId)
 
   return wiringPiI2CSetupInterface (device, devId) ;
 }
+
+
+/*
+ * wiringPiI2CClose:
+ *	Close the I2C device
+ *********************************************************************************
+ */
+
+int wiringPiI2CClose (int fd)
+{
+  return close (fd) ;
+}

--- a/wiringPi/wiringPiI2C.h
+++ b/wiringPi/wiringPiI2C.h
@@ -42,6 +42,7 @@ extern int wiringPiI2CRawWrite       (int fd, const uint8_t *values, uint8_t siz
 
 extern int wiringPiI2CSetupInterface (const char *device, int devId) ;
 extern int wiringPiI2CSetup          (const int devId) ;
+extern int wiringPiI2CClose          (int fd) ;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Adds missing `wiringPiI2CClose()` function for consistent API
- Provides proper cleanup mechanism for I2C file descriptors

## Changes
Added `wiringPiI2CClose()` function that wraps the standard `close()` call. While users could call `close(fd)` directly, this function provides:
- API consistency with other wiringPiI2C functions (`wiringPiI2CSetup`, `wiringPiI2CSetupInterface`)
- Future extensibility for cleanup operations if needed
- Clear semantic meaning in code

## Implementation
- Added function declaration to `wiringPiI2C.h`
- Implemented function in `wiringPiI2C.c`
- Simple wrapper around `close(fd)` for now

Fixes #404